### PR TITLE
Adding support for Redis RDB for persistence and backups

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/backup/RestoreFromS3Task.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/backup/RestoreFromS3Task.java
@@ -149,7 +149,15 @@ public class RestoreFromS3Task extends Task
                      logger.info("Content-Type: "  + 
              		       s3object.getObjectMetadata().getContentType());
              
-                     String filepath = config.getAOFLocation() + "/appendonly.aof";
+                     String filepath = null;
+                     
+                     if(config.isAof()){
+                    	 filepath = config.getPersistenceLocation() + "/appendonly.aof";
+                     }
+                     else {
+                    	 filepath = config.getPersistenceLocation() + "/nfredis.rdb";
+                     }                        
+                  
                      IOUtils.copy(s3object.getObjectContent(), new FileOutputStream(new File(filepath)));       
                   }
                 return true;
@@ -196,4 +204,3 @@ public class RestoreFromS3Task extends Task
     }
     
 }
-

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/resources/DynomiteAdmin.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/resources/DynomiteAdmin.java
@@ -46,6 +46,7 @@ import com.netflix.dynomitemanager.backup.RestoreFromS3Task;
 import com.netflix.dynomitemanager.backup.SnapshotBackup;
 import com.netflix.dynomitemanager.resources.DynomiteAdmin;
 import com.netflix.dynomitemanager.sidecore.scheduler.TaskScheduler;
+import com.netflix.dynomitemanager.sidecore.storage.IStorageProxy;
 
 
 @Path("/v1/admin")
@@ -63,6 +64,7 @@ public class DynomiteAdmin
     private final TaskScheduler scheduler;
     private SnapshotBackup snapshotBackup;
     private RestoreFromS3Task restoreBackup;
+    private IStorageProxy storage;
 
     
     @Inject
@@ -72,7 +74,9 @@ public class DynomiteAdmin
     public DynomiteAdmin(IConfiguration config, IFloridaProcess dynoProcess,
                          InstanceIdentity ii, InstanceState instanceState,
                          SnapshotBackup snapshotBackup, RestoreFromS3Task restoreBackup,
-                         TaskScheduler scheduler)
+                         TaskScheduler scheduler, IStorageProxy storage)
+
+                         
     {
         this.config = config;
         this.dynoProcess = dynoProcess;
@@ -81,6 +85,8 @@ public class DynomiteAdmin
         this.snapshotBackup = snapshotBackup;
         this.restoreBackup = restoreBackup;
         this.scheduler = scheduler;
+        this.storage = storage;
+
     }
 
     @GET
@@ -247,4 +253,23 @@ public class DynomiteAdmin
             return Response.serverError().build();
         }
     }
+    
+    
+    @GET
+    @Path("/takesnapshot")
+    public Response takeSnapshot()
+    {
+    	try
+    	{
+    		logger.info("REST call: Persisting Data to Disk");
+    		this.storage.takeSnapshot();
+            return Response.ok(REST_SUCCESS, MediaType.APPLICATION_JSON).build();
+    	}
+        catch (Exception e)
+        {
+            logger.error("Error while executing data persistence from REST call", e);
+            return Response.serverError().build();
+        }
+    }
+    
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
@@ -45,8 +45,8 @@ public interface IConfiguration
     public String getStorageStartupScript();
     
     
-    /**
-     * @return Script that stops the storage layer
+    /*
+     * 
      */
     public String getStorageStopScript();
     
@@ -88,9 +88,9 @@ public interface IConfiguration
      * @return Get the Data Center name (or region for AWS)
      */
     public String getRack();
-
-    public List<String> getRacks();
     
+    public List<String> getRacks();
+
     
     /**
      * Amazon specific setting to query ASG Membership
@@ -191,8 +191,6 @@ public interface IConfiguration
      
     // Backup and Restore
 
-	public String getAOFLocation();
-
 	public String getBucketName();
 
     public String getBackupLocation();
@@ -201,13 +199,19 @@ public interface IConfiguration
 
     public boolean isRestoreEnabled();
 
+    public String getBackupSchedule();
+    
 	public int getBackupHour();
 	
     public String getRestoreDate();
     
     // Persistence
+    
+	public String getPersistenceLocation();
 
-	boolean isPersistenceAofEnabled();
+	public boolean isPersistenceEnabled();
+
+	public boolean isAof();
 	
 	// Cassandra
     public String getCassandraKeyspaceName();
@@ -217,6 +221,5 @@ public interface IConfiguration
     public String getCommaSeparatedCassandraHostNames();
     
     public boolean isEurekaHostSupplierEnabled();
-
 
 }


### PR DESCRIPTION
* Support for Redis RDB persistence. It provides the ability to configure through the configuration the persistence configuration between AOF and RDB
* Adding the ability to define a cron timer for the backups. Backups can be performed daily or weekly by defining "week" or "day" in the configuration.
* Adding support to take snapshot to disk through REST API