### PR TITLE
warmup and backup enhancements, now rest endpoint

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
@@ -26,14 +26,14 @@ import com.netflix.dynomitemanager.monitoring.RedisInfoMetricsTask;
 import com.netflix.dynomitemanager.monitoring.ServoMetricsTask;
 import com.netflix.dynomitemanager.sidecore.IConfiguration;
 import com.netflix.dynomitemanager.sidecore.aws.UpdateSecuritySettings;
+import com.netflix.dynomitemanager.sidecore.backup.SnapshotTask;
+import com.netflix.dynomitemanager.sidecore.backup.RestoreTask;
 import com.netflix.dynomitemanager.sidecore.scheduler.TaskScheduler;
 import com.netflix.dynomitemanager.sidecore.utils.ProcessMonitorTask;
 import com.netflix.dynomitemanager.sidecore.utils.Sleeper;
 import com.netflix.dynomitemanager.sidecore.utils.ProxyAndStorageResetTask;
 import com.netflix.dynomitemanager.sidecore.utils.TuneTask;
 import com.netflix.dynomitemanager.sidecore.utils.WarmBootstrapTask;
-import com.netflix.dynomitemanager.backup.RestoreFromS3Task;
-import com.netflix.dynomitemanager.backup.SnapshotBackup;
 import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.monitor.Monitors;
 
@@ -106,8 +106,8 @@ public class FloridaServer
         // Determine if we need to restore from backup else start Dynomite.
         if (config.isRestoreEnabled()) {
     		logger.info("Restore is enabled.");
-            scheduler.runTaskNow(RestoreFromS3Task.class); //restore from the AWS
-            logger.info("Scheduled task " + RestoreFromS3Task.JOBNAME);
+            scheduler.runTaskNow(RestoreTask.class); //restore from the AWS
+            logger.info("Scheduled task " + RestoreTask.TaskName);
     	} else { //no restores needed
     		logger.info("Restore is disabled.");
 
@@ -129,7 +129,7 @@ public class FloridaServer
         // Backup       		
         if (config.isBackupEnabled() && config.getBackupHour() >= 0)
         {
-            scheduler.addTask(SnapshotBackup.TaskName, SnapshotBackup.class, SnapshotBackup.getTimer(config));
+            scheduler.addTask(SnapshotTask.TaskName, SnapshotTask.class, SnapshotTask.getTimer(config));
         }
 
         // Metrics

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InstanceState.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InstanceState.java
@@ -18,20 +18,34 @@ package com.netflix.dynomitemanager;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.inject.Singleton;
+import org.joda.time.DateTime;
+
 
 /**
  * Contains the state of the health of processed managed by Florida, and
  * maintains the isHealthy flag used for reporting discovery health check.
+ *
  */
 @Singleton
 public class InstanceState {
     private final AtomicBoolean isSideCarProcessAlive = new AtomicBoolean(false);
     private final AtomicBoolean isBootstrapping = new AtomicBoolean(false);
+    private final AtomicBoolean isBootstrapSuccesful = new AtomicBoolean(false);
+    private final AtomicBoolean firstBootstrap = new AtomicBoolean(true);
     private final AtomicBoolean isBackup = new AtomicBoolean(false);
-    private final AtomicBoolean isRestore = new AtomicBoolean (false);
+    private final AtomicBoolean isBackupSuccessful = new AtomicBoolean(false);
+    private final AtomicBoolean firstBackup = new AtomicBoolean(true);
+    private final AtomicBoolean isRestore = new AtomicBoolean(false);
+    private final AtomicBoolean isRestoreSuccessful = new AtomicBoolean(false);
+    private final AtomicBoolean firstRestore = new AtomicBoolean(true);
     private final AtomicBoolean isStorageProxyAlive = new AtomicBoolean(false);
     private final AtomicBoolean isStorageProxyProcessAlive = new AtomicBoolean(false);
     private final AtomicBoolean isStorageAlive = new AtomicBoolean(false);
+    
+    private long bootstrapTime;
+    private long backupTime;
+    private long restoreTime;
+    
     // This is true if storage proxy and storage are alive.
     private final AtomicBoolean isHealthy = new AtomicBoolean(false);
     // State of whether the rest endpoints /admin/stop or /admin/start are invoked
@@ -43,6 +57,8 @@ public class InstanceState {
         return "InstanceState{" +
                 "isSideCarProcessAlive=" + isSideCarProcessAlive +
                 ", isBootstrapping=" + isBootstrapping +
+                ", isBackingup=" + isBackup +
+                ", isRestoring=" + isRestore +
                 ", isStorageProxyAlive=" + isStorageProxyAlive +
                 ", isStorageProxyProcessAlive=" + isStorageProxyProcessAlive +
                 ", isStorageAlive=" + isStorageAlive +
@@ -63,29 +79,104 @@ public class InstanceState {
     public int metricIsSideCarProcessAlive() {
         return isSideCarProcessAlive() ? 1 : 0;
     }
-
+   
+    /* Boostrap */
     public boolean isBootstrapping() {
         return isBootstrapping.get();
     }
     
+    public boolean isBootstrapSuccessful() {
+    	return isBootstrapSuccesful.get();
+    }
+    
+    public boolean firstBootstrap() {
+    	return firstBootstrap.get();
+    }    
+    
+    public long getBootstrapTime() {
+    	return bootstrapTime;
+    }
+    
+    public void setBootstrapping(boolean isBootstrapping) {
+        this.isBootstrapping.set(isBootstrapping);
+    }
+    
+    public void setBootstrapStatus(boolean isBootstrapSuccesful) {
+        this.isBootstrapSuccesful.set(isBootstrapSuccesful);
+    }
+    
+    public void setFirstBootstrap(boolean firstBootstrap) {
+    	this.firstBootstrap.set(firstBootstrap); 
+    }
+    
+    public void setBootstrapTime(DateTime bootstrapTime) {
+    	this.bootstrapTime = bootstrapTime.getMillis();
+    }
+    
+    /* Backup */
     public boolean isBackingup() {
     	return isBackup.get();
     }
     
-    public boolean isRestoring() {
-    	return isRestore.get();
+    public boolean isBackupSuccessful() {
+    	return isBackupSuccessful.get();
     }
-
-    public void setBootstrapping(boolean isBootstrapping) {
-        this.isBootstrapping.set(isBootstrapping);
+    
+    public boolean firstBackup() {
+    	return firstBackup.get();
+    }    
+    
+    public long getBackupTime() {
+    	return backupTime;
     }
     
     public void setBackingup(boolean isBackup) {
     	this.isBackup.set(isBackup);
     }
     
+    public void setBackUpStatus(boolean isBackupSuccessful) {
+    	this.isBackupSuccessful.set(isBackupSuccessful);
+    }
+    
+    public void setFirstBackup(boolean firstBackup) {
+    	this.firstBackup.set(firstBackup); 
+    }
+    
+    public void setBackupTime(DateTime backupTime) {
+    	this.backupTime = backupTime.getMillis();
+    }
+    
+    /* Restore */
+    public boolean isRestoring() {
+    	return isRestore.get();
+    }
+    
+    public boolean isRestoreSuccessful() {
+    	return isRestoreSuccessful.get();
+    }
+    
+    public boolean firstRestore() {
+    	return firstRestore.get();
+    }
+    
+    public long getRestoreTime() {
+    	return restoreTime;
+    }
+
     public void setRestoring(boolean isRestoring) {
     	this.isRestore.set(isRestoring);
+    }
+    
+    public void setRestoreStatus(boolean isRestoreSuccessful) {
+     this.isRestoreSuccessful.set(isRestoreSuccessful);
+    }
+    
+    public void setFirstRestore(boolean firstRestore) {
+    	this.firstRestore.set(firstRestore); 
+    }  
+
+    public void setRestoreTime(DateTime restoreTime) {
+    	this.restoreTime = restoreTime.getMillis();
     }
 
     //@Monitor(name="bootstrapping", type=DataSourceType.GAUGE)
@@ -141,7 +232,7 @@ public class InstanceState {
     private void setHealthy() {
         this.isHealthy.set(isStorageProxyAlive() && isStorageAlive());
     }
-
+    
     //@Monitor(name="healthy", type=DataSourceType.GAUGE)
     public int metricIsHealthy() {
         return isHealthy() ? 1 : 0;
@@ -159,4 +250,5 @@ public class InstanceState {
     public int metricIsProcessMonitoringSuspended() {
         return getIsProcessMonitoringSuspended() ? 1 : 0;
     }
+
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/CassandraInstanceFactory.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/CassandraInstanceFactory.java
@@ -31,7 +31,7 @@ import com.google.inject.Singleton;
 import com.netflix.dynomitemanager.sidecore.IConfiguration;
 
 /**
- * Factory to use cassandra for managing instance data 
+ * Factory to use Cassandra for managing instance data 
  */
 
 @Singleton
@@ -58,6 +58,18 @@ public class CassandraInstanceFactory implements IAppsInstanceFactory
         sort(return_);
         return return_;
     }
+    
+    public List<AppsInstance> getLocalDCIds(String appName, String region)
+    {
+        List<AppsInstance> return_ = new ArrayList<AppsInstance>();
+        for (AppsInstance instance : dao.getLocalDCInstances(appName, region)) {
+            return_.add(instance);
+        }
+
+        sort(return_);
+        return return_;
+    }
+
 
     public void sort(List<AppsInstance> return_)
     {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/IAppsInstanceFactory.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/IAppsInstanceFactory.java
@@ -32,6 +32,15 @@ public interface IAppsInstanceFactory
      */
     public List<AppsInstance> getAllIds(String appName);
 
+    
+    /**
+     * Return a list of Local Dynomite server nodes registered.
+     * @param appName the cluster name
+     * @param region the the region of the node
+     * @return a list of nodes in {@code appName} and same Racks
+     */
+	public List<AppsInstance> getLocalDCIds(String appName, String region);    
+    
     /**
      * Return the Dynomite server node with the given {@code id}.
      * @param appName the cluster name
@@ -80,4 +89,5 @@ public interface IAppsInstanceFactory
      * @param device
      */
     public void attachVolumes(AppsInstance instance, String mountPath, String device);
+
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceDataDAOCassandra.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceDataDAOCassandra.java
@@ -251,6 +251,18 @@ public class InstanceDataDAOCassandra
 		}
 		return null;
 	}
+	
+	public Set<AppsInstance> getLocalDCInstances(String app, String region)
+	{
+		Set<AppsInstance> set = getAllInstances(app);
+		Set<AppsInstance> returnSet = new HashSet<AppsInstance>();
+
+		for (AppsInstance ins : set) {
+			if (ins.getDatacenter().equals(region))
+				returnSet.add(ins);
+		}
+		return returnSet;
+	}
 
 	public Set<AppsInstance> getAllInstances(String app)
 	{

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/Backup.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/Backup.java
@@ -1,0 +1,12 @@
+package com.netflix.dynomitemanager.sidecore.backup;
+
+import java.io.File;
+
+import org.joda.time.DateTime;
+
+import com.netflix.dynomitemanager.sidecore.ICredential;
+
+
+public interface Backup {
+      boolean upload(File file, DateTime todayStart);
+}

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/Restore.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/Restore.java
@@ -1,0 +1,5 @@
+package com.netflix.dynomitemanager.sidecore.backup;
+
+public interface Restore {
+	boolean restoreData(String dateString);
+}

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/RestoreTask.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/RestoreTask.java
@@ -1,0 +1,119 @@
+package com.netflix.dynomitemanager.sidecore.backup;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.netflix.dynomitemanager.IFloridaProcess;
+import com.netflix.dynomitemanager.InstanceState;
+import com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfiguration;
+import com.netflix.dynomitemanager.defaultimpl.StorageProcessManager;
+import com.netflix.dynomitemanager.identity.InstanceIdentity;
+import com.netflix.dynomitemanager.sidecore.IConfiguration;
+import com.netflix.dynomitemanager.sidecore.ICredential;
+import com.netflix.dynomitemanager.sidecore.scheduler.Task;
+import com.netflix.dynomitemanager.sidecore.storage.IStorageProxy;
+import com.netflix.dynomitemanager.sidecore.utils.JedisUtils;
+import com.netflix.dynomitemanager.sidecore.utils.Sleeper;
+
+
+/**
+ * Task for restoring snapshots from object storage
+ */
+
+@Singleton
+public class RestoreTask extends Task
+{
+	public static final String TaskName =  "RestoreTask";
+	private static final Logger logger = LoggerFactory.getLogger(RestoreTask.class);
+    private final ICredential cred;
+    private final InstanceIdentity iid;
+    private final InstanceState state;
+    private final IStorageProxy storageProxy;
+    private final IFloridaProcess dynProcess;
+    private final Sleeper sleeper;
+    private final Restore restore;
+
+
+    @Inject
+    private StorageProcessManager storageProcessMgr;
+    
+    @Inject
+    public RestoreTask(IConfiguration config, InstanceIdentity id, ICredential cred, InstanceState state,
+    		IStorageProxy storageProxy, IFloridaProcess dynProcess, Sleeper sleeper, Restore restore)
+    {
+        super(config);
+        this.cred = cred;
+        this.iid = id;
+        this.state = state;
+        this.storageProxy = storageProxy;
+        this.dynProcess = dynProcess;
+        this.sleeper = sleeper;
+        this.restore = restore;
+    }
+    
+    
+    public void execute() throws Exception
+    {
+    	this.state.setRestoring(true);
+    	this.state.setFirstRestore(false);
+ 	   /** 
+ 	    * Set the status of the restore to "false" every time we start a restore.
+ 	    * This will ensure that prior to restore we recapture the status of the restore.
+ 	    */
+        this.state.setRestoreStatus(false);
+        
+    	/* stop dynomite process */
+    	this.dynProcess.stop();
+    	    	
+    	/* stop storage process */
+    	this.storageProcessMgr.stop();    	
+
+    	/* restore from Object Storage */
+    	if(restore.restoreData(config.getRestoreDate())){
+        	/* start storage process and load data */
+        	logger.info("Restored successful: Starting storage process with loading data.");
+        	this.storageProcessMgr.start();
+        	if(!this.storageProxy.loadingData()){
+            	logger.error("Restore not successful: Restore failed because of Redis.");
+        	}
+        	logger.info("Restore Completed, sleeping 5 seconds before starting Dynomite!");
+        	
+        	sleeper.sleepQuietly(5000);
+        	this.dynProcess.start(true);   	
+        	logger.info("Dynomite started");
+        	this.state.setRestoreStatus(true);
+    	} else {
+        	/* start storage process without loading data */
+        	logger.error("Restore not successful: Starting storage process without loading data.");
+    	}
+    	this.state.setRestoring(false);
+    	this.state.setRestoreTime(DateTime.now());
+    }
+    
+    @Override
+    public String getName()
+    {
+        return TaskName;
+    }
+    
+}
+ 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Backup.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Backup.java
@@ -1,0 +1,157 @@
+package com.netflix.dynomitemanager.sidecore.backup;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.joda.time.DateTime;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ResponseMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.CreateBucketRequest;
+import com.amazonaws.services.s3.model.GetBucketLocationRequest;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+
+
+import com.netflix.dynomitemanager.sidecore.IConfiguration;
+import com.netflix.dynomitemanager.sidecore.ICredential;
+import com.netflix.dynomitemanager.identity.InstanceIdentity;
+
+
+@Singleton
+public class S3Backup implements Backup {
+
+	private static final Logger logger = LoggerFactory.getLogger(S3Backup.class);
+    private final long initPartSize = 500 * 1024 * 1024; // we set the part size equal to 500MB. We do not want this too large 
+	     // and run out of heap space
+	
+    @Inject
+    private IConfiguration config; 
+    
+    @Inject
+    private ICredential cred; 
+    
+    @Inject
+    private InstanceIdentity iid;
+    
+    /**
+     * Uses the Amazon S3 API to upload the AOF/RDB to S3
+     * Filename: Backup location + DC + Rack + App + Token
+     */
+	@Override
+	public boolean upload(File file, DateTime todayStart) {
+    	logger.info("Snapshot backup: sending " + file.length() + " bytes to S3");
+        
+        /* Key name is comprised of the 
+        * backupDir + DC + Rack + token + Date
+        */
+        String keyName = 
+        		config.getBackupLocation() + "/" +
+        		iid.getInstance().getDatacenter() + "/" +
+        		iid.getInstance().getRack() + "/" +
+        		iid.getInstance().getToken() + "/" +
+        		todayStart.getMillis();
+
+        // Get bucket location.
+        logger.info("Key in Bucket: " + keyName);
+        logger.info("S3 Bucket Name:" + config.getBucketName());
+
+    	AmazonS3Client s3Client = new AmazonS3Client(cred.getAwsCredentialProvider());
+
+    	
+        try {
+            // Checking if the S3 bucket exists, and if does not, then we create it
+        	
+            if(!(s3Client.doesBucketExist(config.getBucketName()))) {
+      	       logger.error("Bucket with name: " + config.getBucketName() + " does not exist");
+      	       return false;
+            }
+            else {
+                logger.info("Uploading data to S3\n");
+            	// Create a list of UploadPartResponse objects. You get one of these for
+            	// each part upload.
+            	List<PartETag> partETags = new ArrayList<PartETag>();
+            	
+                InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(
+                		config.getBucketName(), keyName);
+                
+                InitiateMultipartUploadResult initResponse = 
+                        s3Client.initiateMultipartUpload(initRequest);
+                
+                long contentLength = file.length();
+                long filePosition = 0;
+                long partSize  = this.initPartSize;
+
+                try {
+                    for (int i = 1; filePosition < contentLength; i++) {
+                        // Last part can be less than initPartSize (500MB). Adjust part size.
+                    	partSize = Math.min(partSize, (contentLength - filePosition));
+                    	
+                        // Create request to upload a part.
+                        UploadPartRequest uploadRequest = new UploadPartRequest()
+                            .withBucketName(config.getBucketName()).withKey(keyName)
+                            .withUploadId(initResponse.getUploadId()).withPartNumber(i)
+                            .withFileOffset(filePosition)
+                            .withFile(file)
+                            .withPartSize(partSize);
+                        
+                        // Upload part and add response to our list.
+                        partETags.add(s3Client.uploadPart(uploadRequest).getPartETag());
+
+                        filePosition += partSize;
+                    }
+
+                    CompleteMultipartUploadRequest compRequest = new 
+                                CompleteMultipartUploadRequest(config.getBucketName(), 
+                                                               keyName, 
+                                                               initResponse.getUploadId(), 
+                                                               partETags);
+
+                    s3Client.completeMultipartUpload(compRequest);
+                
+                } catch (Exception e) {
+                	logger.error("Abosting multipart upload due to error");
+                    s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(
+                    		config.getBucketName(), keyName, initResponse.getUploadId()));
+                }
+                
+         	    return true;
+            }
+       } catch (AmazonServiceException ase) {
+    	   
+    	   logger.error("AmazonServiceException;" +
+           		" request made it to Amazon S3, but was rejected with an error ");
+    	   logger.error("Error Message:    " + ase.getMessage());
+    	   logger.error("HTTP Status Code: " + ase.getStatusCode());
+    	   logger.error("AWS Error Code:   " + ase.getErrorCode());
+    	   logger.error("Error Type:       " + ase.getErrorType());
+    	   logger.error("Request ID:       " + ase.getRequestId());
+    	   return false;
+           
+       } catch (AmazonClientException ace) {
+    	   logger.error("AmazonClientException;"+
+           		" the client encountered " +
+                   "an internal error while trying to " +
+                   "communicate with S3, ");
+    	   logger.error("Error Message: " + ace.getMessage());
+    	   return false;
+       }
+    }
+}

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Restore.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Restore.java
@@ -1,19 +1,4 @@
-/**
- * Copyright 2016 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.netflix.dynomitemanager.backup;
+package com.netflix.dynomitemanager.sidecore.backup;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,99 +16,41 @@ import org.joda.time.format.DateTimeFormatter;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.netflix.dynomitemanager.sidecore.IConfiguration;
+import com.netflix.dynomitemanager.sidecore.ICredential;
+import com.netflix.dynomitemanager.identity.InstanceIdentity;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import com.netflix.dynomitemanager.IFloridaProcess;
-import com.netflix.dynomitemanager.InstanceState;
-import com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfiguration;
-import com.netflix.dynomitemanager.defaultimpl.StorageProcessManager;
-import com.netflix.dynomitemanager.identity.InstanceIdentity;
-import com.netflix.dynomitemanager.sidecore.IConfiguration;
-import com.netflix.dynomitemanager.sidecore.ICredential;
-import com.netflix.dynomitemanager.sidecore.scheduler.Task;
-import com.netflix.dynomitemanager.sidecore.storage.IStorageProxy;
-import com.netflix.dynomitemanager.sidecore.utils.JedisUtils;
-import com.netflix.dynomitemanager.sidecore.utils.Sleeper;
-
-
-/**
- * Task for restoring snapshots from S3
- */
 
 @Singleton
-public class RestoreFromS3Task extends Task
-{
-	public static final String JOBNAME =  "Restore";
-	private static final Logger logger = LoggerFactory.getLogger(RestoreFromS3Task.class);
-    private final ICredential cred;
-    private final InstanceIdentity iid;
-    private final InstanceState state;
-    private final IStorageProxy storageProxy;
-    private final IFloridaProcess dynProcess;
-    private final Sleeper sleeper;
+public class S3Restore implements Restore {
 
+	private static final Logger logger = LoggerFactory.getLogger(S3Restore.class);
 
     @Inject
-    private StorageProcessManager storageProcessMgr;
+    private IConfiguration config; 
     
     @Inject
-    public RestoreFromS3Task(IConfiguration config, InstanceIdentity id, ICredential cred, InstanceState state,
-    		IStorageProxy storageProxy, IFloridaProcess dynProcess, Sleeper sleeper)
-    {
-        super(config);
-        this.cred = cred;
-        this.iid = id;
-        this.state = state;
-        this.storageProxy = storageProxy;
-        this.dynProcess = dynProcess;
-        this.sleeper = sleeper;
-    }
+    private ICredential cred; 
     
+    @Inject
+    private InstanceIdentity iid;
     
-    public void execute() throws Exception
-    {
-    	this.state.setRestoring(true);
-    	
-    	/* stop dynomite process */
-    	this.dynProcess.stop();
-    	    	
-    	/* stop storage process */
-    	this.storageProcessMgr.stop();    	
-
-    	/* restore from S3 */
-    	if(restoreFromS3(config.getRestoreDate())){
-        	/* start storage process and load data */
-        	logger.info("S3 Restored successful: Starting storage process with loading data.");
-        	this.storageProcessMgr.start();
-        	if(!this.storageProxy.loadingData()){
-            	logger.error("S3 Restore not successful: Restore failed because of Redis.");
-        	}
-        	logger.info("Restore Completed, sleeping 5 seconds before starting Dynomite!");
-        	
-        	sleeper.sleepQuietly(5000);
-        	this.dynProcess.start(true);   	
-    	} else {
-        	/* start storage process without loading data */
-        	logger.error("S3 Restore not successful: Starting storage process without loading data.");
-    	}
-    	this.state.setRestoring(false);
-    }
-    
-    public String getName()
-    {
-        return JOBNAME;
-    }
-    
-    private boolean restoreFromS3(String dateString)
+	
+	/**
+     * Uses the Amazon S3 API to restore from S3
+     */
+	@Override
+	public boolean restoreData(String dateString)
     {
     	long time = restoreTime(dateString);
     	if (time > -1) {
            logger.info("Restoring data from S3.");        
-    	   AmazonS3Client s3Client = new AmazonS3Client(this.cred.getAwsCredentialProvider());
+    	   AmazonS3Client s3Client = new AmazonS3Client(cred.getAwsCredentialProvider());
 
            try {
                /* construct the key for the backup data */

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/IStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/IStorageProxy.java
@@ -15,11 +15,14 @@
  */
 package com.netflix.dynomitemanager.sidecore.storage;
 
+import com.netflix.dynomitemanager.IFloridaProcess;
+
+
 public interface IStorageProxy {
     
     boolean isAlive();
     long getUptime();
-    boolean warmUpStorage(String[] peers);
+    boolean warmUpStorage(String[] peers, IFloridaProcess dynProcess);
     boolean resetStorage();
     boolean takeSnapshot();
     boolean loadingData();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/MemcachedStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/MemcachedStorageProxy.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.dynomitemanager.sidecore.storage;
 
+import com.netflix.dynomitemanager.IFloridaProcess;
+
 public class MemcachedStorageProxy implements IStorageProxy {
 
     @Override
@@ -28,10 +30,10 @@ public class MemcachedStorageProxy implements IStorageProxy {
     }
 
     @Override
-    public boolean warmUpStorage(String[] peers) {
-        // TODO Auto-generated method stub
+    public boolean warmUpStorage(String[] peers, IFloridaProcess dynProcess) {
         return false;
     }
+    
     
     @Override
     public boolean resetStorage() {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -15,6 +15,8 @@
  */
 package com.netflix.dynomitemanager.sidecore.storage;
 
+import java.io.IOException;
+
 import com.google.common.base.Splitter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -25,16 +27,18 @@ import com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfiguration;
 import com.netflix.dynomitemanager.sidecore.IConfiguration;
 import com.netflix.dynomitemanager.sidecore.utils.JedisUtils;
 import com.netflix.dynomitemanager.sidecore.utils.Sleeper;
+import com.netflix.dynomitemanager.IFloridaProcess;
+
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
-
 import static com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfiguration.LOCAL_ADDRESS;
 import static com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfiguration.REDIS_PORT;
 
@@ -42,449 +46,482 @@ import static com.netflix.dynomitemanager.defaultimpl.DynomitemanagerConfigurati
 //TODOs: we should talk to admin port (22222) instead of 8102 for both local and peer
 @Singleton
 public class RedisStorageProxy implements IStorageProxy {
-    
+  
 	private static final Logger logger = LoggerFactory.getLogger(RedisStorageProxy.class);
 
-    private Jedis localJedis;
-    private final DynamicStringProperty adminUrl = 
-            DynamicPropertyFactory.getInstance().getStringProperty("dynomitemanager.metrics.url", "http://localhost:22222");
-    //private final HttpClient client = new HttpClient();
+  private Jedis localJedis;
+  private final DynamicStringProperty adminUrl = 
+          DynamicPropertyFactory.getInstance().getStringProperty("florida.metrics.url", "http://localhost:22222");
+  //private final HttpClient client = new HttpClient();
 
-    @Inject
-    private IConfiguration config; 
+  @Inject
+  private IConfiguration config; 
 
-    @Inject
-    private Sleeper sleeper;
+  @Inject
+  private Sleeper sleeper;
 
-    @Inject
-    private InstanceState instanceState;
+  @Inject
+  private InstanceState instanceState;
 
-    public RedisStorageProxy() {
-        //connect();
-    }
-    
-    private void connect() {
-        try {
-            if (localJedis == null)
-               localJedis = new Jedis(LOCAL_ADDRESS, REDIS_PORT, 5000);
-            else localJedis.disconnect();
-            
-            localJedis.connect();
-        } catch (Exception e) {
-            logger.info("Unable to connect: " + e.getMessage());
-        }
-    }
-    
-    
+  public RedisStorageProxy() {
+      //connect();
+  }
+  
+  private void connect() {
+      try {
+          if (localJedis == null)
+             localJedis = new Jedis(LOCAL_ADDRESS, REDIS_PORT, 5000);
+          else localJedis.disconnect();
+          
+          localJedis.connect();
+      } catch (Exception e) {
+          logger.info("Unable to connect: " + e.getMessage());
+      }
+  }
+  
+  
 /*    private boolean isAlive(Jedis jedis) {
-        try {
-           jedis.ping();
-        } catch (JedisConnectionException e) {
-            connect();
-            return false; 
-        } catch (Exception e) {
-            connect();
-            return false;
-        }
-        return true;
-    }*/
-    
-    //issue a 'slaveof peer port to local redis
-    private void startPeerSync(String peer, int port) { 
-        boolean isDone = false;
-        connect();
-        
-        while (!isDone) {
-           try {
-               //only sync from one peer for now
-               isDone = (localJedis.slaveof(peer, port) != null);
-               sleeper.sleepQuietly(1000);
-           } catch (JedisConnectionException e) {
-               connect();
-           } catch (Exception e) {
-               connect();
-           }
-        }
-    }
-    
-    //issue a 'slaveof no one' to local reids
-    //set dynomite to accept writes but no reads
-    private void stopPeerSync() {
-        boolean isDone = false;
-        
-        while (!isDone) {
-            logger.info("calling slaveof no one");
-            try {
-               isDone = (localJedis.slaveofNoOne() != null);
-               sleeper.sleepQuietly(1000);
-               
-            } catch (JedisConnectionException e) {
-               logger.error("Error: " + e.getMessage());
-               connect();
-            } catch (Exception e) {
-               logger.error("Error: " + e.getMessage()); 
-               connect();
-            }
-        }
-    }
-
-    @Override
-    public boolean takeSnapshot()
-    {
-        String scheduled = "ERR Background append only file rewriting already in progress";
-        connect();
-        logger.info("starting Redis BGREWRITEAOF");
-        try {
-
-        	localJedis.bgrewriteaof();
-        	/* We want to check if a bgrewriteaof was already scheduled
-        	 * or it has started. If a bgrewriteaof was already scheduled
-        	 * then we should get an error from Redis but should continue.
-        	 * If a bgrewriteaof has started, we should also continue.
-        	 * Otherwise we may be having old data in the disk.
-        	 */
-        } catch (JedisDataException e) {
-            if(!e.getMessage().equals(scheduled)){
-                throw e;
-            }
-        	logger.warn("Redis: There is already a pending BGREWRITEAOF.");
-        }
-
-        String peerRedisInfo = null;
-        int retry = 0;
-        
-        try {
-            while(true) {
-            	peerRedisInfo = localJedis.info();
-                Iterable<String> result = Splitter.on('\n').split(peerRedisInfo); 
-                String pendingAOF = null;
-                
-                for(String line : result) {
-                    if (line.startsWith("aof_rewrite_in_progress")) {
-                        String[] items = line.split(":");
-                        pendingAOF = items[1].trim();
-                        if(pendingAOF.equals("0")){
-                        	logger.info("Redis: BGREWRITEAOF completed.");
-                        	return true;
-                        } else {
-                        	retry++;
-                        	logger.warn("Redis: BGREWRITEAOF pending. Sleeping 30 secs...");
-                            sleeper.sleepQuietly(30000);
-
-                            if (retry > 20) {
-                            	return false;
-                            }
-                        }
-                    }
-                }
-            }
-            
-        } catch (JedisConnectionException e) {
-        	logger.error("Cannot connect to Redis to perform BGREWRITEAOF");
-        }
-       
-        logger.error("Redis BGREWRITEAOF was not succesful.");
- 	   return false;
-
-    }
-
-
-    @Override
-    public boolean loadingData()
-    {
-    	connect();
-        logger.info("loading AOF from the drive");
-        String peerRedisInfo = null;
-        int retry = 0;
-        
-        try {
-        	peerRedisInfo = localJedis.info();
-            Iterable<String> result = Splitter.on('\n').split(peerRedisInfo); 
-            String pendingAOF = null;
-            
-            for(String line : result) {
-                if (line.startsWith("loading")) {
-                	 String[] items = line.split(":");
-                     pendingAOF = items[1].trim();
-                     if(pendingAOF.equals("0")){
-                     	logger.info("Redis: memory loading completed.");
-                     	return true;
-                     } else {
-                     	retry++;
-                     	logger.warn("Redis: memory pending. Sleeping 30 secs...");
-                         sleeper.sleepQuietly(30000);
-
-                         if (retry > 20) {
-                         	return false;
-                         }
-                     }
-                 }
-             }
-        } catch (JedisConnectionException e) {
-    	   logger.error("Cannot connect to Redis to load the AOF");
-        }
-        
- 	   return false;
-
-    }
-
-
-    @Override
-    public boolean isAlive() {
-        // Not using localJedis variable as it can be used by
-        // ProcessMonitorTask as well.
-        return JedisUtils.isAliveWithRetry(LOCAL_ADDRESS, REDIS_PORT);
-    }
-
-    @Override
-    public long getUptime() {
-        
-        return 0;
-    }
-
-    @Override
-    //probably use our Retries Util here
-    public boolean warmUpStorage(String[] peers) {
-        String alivePeer = null;
-        Jedis peerJedis = null;
-        
-        for(String peer : peers) {
-            logger.info("Peer node [" + peer + "] has the same token!" );
-            peerJedis = JedisUtils.connect(peer, config.getListenerPort());
-            if (peerJedis != null && isAlive()) {
-                alivePeer = peer;
-                break;
-            } 
-        }
-
-        if (alivePeer != null && peerJedis != null) {   
-            logger.info("Issue slaveof commnd on peer[" + alivePeer + "] and port[" + REDIS_PORT + "]");
-            startPeerSync(alivePeer, REDIS_PORT);
-            
-            logger.info("Force Dynomite to be in Standby mode!");
-            sendCommand("/state/standby");
-            
-            long diff = 0;
-            long previousDiff = 0;
-            short retry = 0;
-            short numErrors = 0;
-            long startTime = System.currentTimeMillis();
-            
-            /*
-             * Conditions under which warmp up will end
-             * 1. number of Jedis errors are 5.
-             * 2. number of consecutive increases of offset differences (caused when client produces high load).
-             * 3. the difference between offsets is very small or zero (success).
-             * 4. warmp up takes more than 15 minutes.
-             */
-            
-            while (numErrors < 5) {
-                sleeper.sleepQuietly(10000);
-                try {
-                    diff = canPeerSyncStop(peerJedis, startTime);
-                } catch (Exception e) {
-                	numErrors++;
-                }
-                
-                /*
-                 * Diff meaning:
-                 * a. diff ==  0 --> we are either in sync or close to sync.
-                 * b. diff == -1 --> that there was an error in sync process.
-                 * c. diff == -2 --> offset is still zero, peer syncing has not started.
-                 */
-                if (diff == 0 || diff == -1 ) {
-                	break;
-                }
-                else if (diff == -2 ) {
-                	startTime = System.currentTimeMillis();
-                }
-
-             
-                
-                /*
-                 * Exit conditions:
-                 * a. retry more than 5 time continuously and if the diff is larger than the previous diff.
-                 */
-                if (previousDiff < diff) {
-                	logger.info("Previous diff was smaller than current diff ---> Retry effort: " + retry);
-                	retry++;
-                	if (retry == 5){
-                    	logger.info("Reached 5 consecutive retries, peer syncing cannot complete");
-                    	break;
-                	}
-                }
-                else{
-                	retry = 0;
-                }
-                previousDiff = diff;
-            }
-
-            logger.info("Set Dynomite to allow writes only!!!");
-            sendCommand("/state/writes_only");
-            
-            logger.info("Stop Redis' Peer syncing!!!");
-            stopPeerSync();
-            
-            logger.info("Set Dynomite to resuming state to allow writes and flush delayed writes");
-            sendCommand("/state/resuming");
-            
-            //sleep 15s for the flushing to catch up
-            sleeper.sleepQuietly(15000);
-            logger.info("Set Dynomite to normal state");
-            sendCommand("/state/normal");
-            
-            peerJedis.disconnect();
-
-            if (diff > 0) {
-                logger.error("Peer sync can't finish!  Something is wrong.");
-                return false;
-            }
-        }
-
-        return true;
-    }
-    /**
-     * Resets Redis to master if it was slave due to warm up failure.
-     */
-    @Override
-    public boolean resetStorage() {
-    	logger.info("Checking if Redis needs to be resetted to master");
-        connect();
-        String peerRedisInfo = null;
-        try {
-        	peerRedisInfo = localJedis.info();
-        } catch (JedisConnectionException e) {
-        	// Try to reconnect
-        	try {
-        		connect();
-            	peerRedisInfo = localJedis.info();
-        	} catch (JedisConnectionException ex) {
-        		logger.error("Cannot connect to Redis");
-        		return false;
-        	}
-        }
-        Iterable<String> result = Splitter.on('\n').split(peerRedisInfo);
-        
-        String role = null;
-
-        for(String line : result) {
-            if (line.startsWith("role")) {
-                String[] items = line.split(":");
-             //   logger.info(items[0] + ": " + items[1]);
-                role = items[1].trim();
-                if(role.equals("slave")){
-                	logger.info("Redis: slave ----> master");
-                	stopPeerSync();
-                }
-                return true;
-            }
-        }
-        
-        return false;
-
-    }
-
-
-    private Long canPeerSyncStop(Jedis peerJedis, long startTime) throws RedisSyncException {
-    	
-    	if (System.currentTimeMillis() - startTime > config.getMaxTimeToBootstrap()) {
-           	logger.warn("Warm up takes more than 15 minutes --> moving on");
-           	return (long) -1;
-        }
-    	
-        logger.info("Checking for peer syncing");
-        String peerRedisInfo = peerJedis.info();
-        
-        Long masterOffset = -1L;
-        Long slaveOffset = -1L;
-        
-        //get peer's repl offset
-        Iterable<String> result = Splitter.on('\n').split(peerRedisInfo);
-        
-        for(String line : result) {
-            if (line.startsWith("master_repl_offset")) {
-                String[] items = line.split(":");
-                logger.info(items[0] + ": " + items[1]);
-                masterOffset = Long.parseLong(items[1].trim());
-                
-            }
-            
-            //slave0:ip=10.99.160.121,port=22122,state=online,offset=17279,lag=0
-            if (line.startsWith("slave0")) {
-                String[] items = line.split(",");
-                for(String item : items) {
-                    if (item.startsWith("offset")) {
-                        String[] offset = item.split("=");
-                        logger.info(offset[0] + ": " + offset[1]);
-                        slaveOffset = Long.parseLong(offset[1].trim());
-                    }           
-                }
-            }
-        }
-
-        if (slaveOffset == -1) {
-        	logger.error("Slave offset could not be parsed --> check memory overcommit configuration");
-        	return (long) -1;
-        }
-        else if (slaveOffset == 0) {
-        	logger.info("Slave offset is zero ---> Redis master node still dumps data to the disk");
-        	return (long) -2;
-        }
-        Long diff = Math.abs(masterOffset - slaveOffset);
-        
-        logger.info("masterOffset: " + masterOffset + " slaveOffset: " + slaveOffset + 
-        		" current Diff: " + diff + 
-        		" allowable diff: " + config.getAllowableBytesSyncDiff());
-        /* 
-         * Allowable bytes sync diff can be configured by a Fast Property.
-         * If the difference is very small, then we return zero.
-         */
-        if (diff < config.getAllowableBytesSyncDiff()) {
-            logger.info("master and slave are in sync!");
-            return (long) 0;
-        }
-        else if (slaveOffset == 0) {
-        	logger.info("slave has not started syncing");
-        }
-        return diff;
-    }
-    
-    private class RedisSyncException extends Exception {
-         public RedisSyncException(String msg) {
-             super(msg);
+      try {
+         jedis.ping();
+      } catch (JedisConnectionException e) {
+          connect();
+          return false; 
+      } catch (Exception e) {
+          connect();
+          return false;
+      }
+      return true;
+  }*/
+  
+  //issue a 'slaveof peer port to local redis
+  private void startPeerSync(String peer, int port) { 
+      boolean isDone = false;
+      connect();
+      
+      while (!isDone) {
+         try {
+             //only sync from one peer for now
+             isDone = (localJedis.slaveof(peer, port) != null);
+             sleeper.sleepQuietly(1000);
+         } catch (JedisConnectionException e) {
+             connect();
+         } catch (Exception e) {
+             connect();
          }
-    }
-    
-    private boolean sendCommand(String cmd) {
-        String url = adminUrl.get() + cmd;
-        HttpClient client = new HttpClient();
-        client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, 
-                                        new DefaultHttpMethodRetryHandler());
-        
-        GetMethod get = new GetMethod(url);
-        try {
-            int statusCode = client.executeMethod(get);
-            if (!(statusCode == 200)) {
-                logger.error("Got non 200 status code from " + url);
-                return false;
-            }
-            
-            String response = get.getResponseBodyAsString();
-            //logger.info("Received response from " + url + "\n" + response);
-            
-            if (!response.isEmpty()) {
-                logger.info("Received response from " + url + "\n" + response);
-            } else {
-                logger.error("Cannot parse empty response from " + url);
-                return false;
-            }
-            
-        } catch (Exception e) {
-            logger.error("Failed to sendCommand and invoke url: " + url, e);
-            return false;
-        }
-        
-        return true;
-    }
+      }
+  }
+  
+  //issue a 'slaveof no one' to local reids
+  //set dynomite to accept writes but no reads
+  private void stopPeerSync() {
+      boolean isDone = false;
+      
+      while (!isDone) {
+          logger.info("calling slaveof no one");
+          try {
+             isDone = (localJedis.slaveofNoOne() != null);
+             sleeper.sleepQuietly(1000);
+             
+          } catch (JedisConnectionException e) {
+             logger.error("JedisConnection Exception in Slave of None: " + e.getMessage());
+             connect();
+          } catch (Exception e) {
+             logger.error("Error: " + e.getMessage()); 
+             connect();
+          }
+      }
+  }
+
+  @Override
+  public boolean takeSnapshot()
+  {           
+      connect();
+      try {
+      	if(config.isAof()) {
+             logger.info("starting Redis BGREWRITEAOF");
+      	   localJedis.bgrewriteaof();
+      	}
+      	else {
+             logger.info("starting Redis BGSAVE");
+      	   localJedis.bgsave();
+
+      	}
+      	/* We want to check if a bgrewriteaof was already scheduled
+      	 * or it has started. If a bgrewriteaof was already scheduled
+      	 * then we should get an error from Redis but should continue.
+      	 * If a bgrewriteaof has started, we should also continue.
+      	 * Otherwise we may be having old data in the disk.
+      	 */
+      } catch (JedisDataException e) {
+      	String scheduled = null;
+      	if (!config.isAof()) {
+      		scheduled = "ERR Background save already in progress";
+      	}
+      	else {
+              scheduled = "ERR Background append only file rewriting already in progress";
+      	}
+      	
+          if(!e.getMessage().equals(scheduled)){
+              throw e;
+          }
+      	logger.warn("Redis: There is already a pending BGREWRITEAOF/BGSAVE.");
+      }
+
+      String peerRedisInfo = null;
+      int retry = 0;
+      
+      try {
+          while(true) {
+          	peerRedisInfo = localJedis.info();
+              Iterable<String> result = Splitter.on('\n').split(peerRedisInfo); 
+              String pendingPersistence = null;
+              
+              for(String line : result) {
+                  if ((line.startsWith("aof_rewrite_in_progress") && config.isAof())  || 
+                  		(line.startsWith("rdb_bgsave_in_progress") && !config.isAof())) {
+                      String[] items = line.split(":");
+                      pendingPersistence = items[1].trim();
+                      if(pendingPersistence.equals("0")){
+                      	logger.info("Redis: BGREWRITEAOF/BGSAVE completed.");
+                      	return true;
+                      } else {
+                      	retry++;
+                      	logger.warn("Redis: BGREWRITEAOF/BGSAVE pending. Sleeping 30 secs...");
+                          sleeper.sleepQuietly(30000);
+
+                          if (retry > 20) {
+                          	return false;
+                          }
+                      }
+                  }
+              }
+          }
+          
+      } catch (JedisConnectionException e) {
+      	logger.error("Cannot connect to Redis to perform BGREWRITEAOF/BGSAVE");
+      }
+     
+      logger.error("Redis BGREWRITEAOF/BGSAVE was not succesful.");
+	   return false;
+
+  }
+
+
+  @Override
+  public boolean loadingData()
+  {
+  	connect();
+      logger.info("loading AOF from the drive");
+      String peerRedisInfo = null;
+      int retry = 0;
+      
+      try {
+      	peerRedisInfo = localJedis.info();
+          Iterable<String> result = Splitter.on('\n').split(peerRedisInfo); 
+          String pendingAOF = null;
+          
+          for(String line : result) {
+              if (line.startsWith("loading")) {
+              	 String[] items = line.split(":");
+                   pendingAOF = items[1].trim();
+                   if(pendingAOF.equals("0")){
+                   	logger.info("Redis: memory loading completed.");
+                   	return true;
+                   } else {
+                   	retry++;
+                   	logger.warn("Redis: memory pending. Sleeping 30 secs...");
+                       sleeper.sleepQuietly(30000);
+
+                       if (retry > 20) {
+                       	return false;
+                       }
+                   }
+               }
+           }
+      } catch (JedisConnectionException e) {
+  	   logger.error("Cannot connect to Redis to load the AOF");
+      }
+      
+	   return false;
+
+  }
+
+
+  @Override
+  public boolean isAlive() {
+      // Not using localJedis variable as it can be used by
+      // ProcessMonitorTask as well.
+      return JedisUtils.isAliveWithRetry(LOCAL_ADDRESS, REDIS_PORT);
+  }
+
+  @Override
+  public long getUptime() {
+      
+      return 0;
+  }
+
+  @Override
+  //probably use our Retries Util here
+  public boolean warmUpStorage(String[] peers, IFloridaProcess dynProcess) {
+      String alivePeer = null;
+      Jedis peerJedis = null;
+      
+      // Identify if we can connect with the peer node
+      for(String peer : peers) {
+          logger.info("Peer node [" + peer + "] has the same token!" );
+          peerJedis = JedisUtils.connect(peer, config.getListenerPort());
+          if (peerJedis != null && isAlive()) {
+              alivePeer = peer;
+              break;
+          } 
+      }
+      
+      // We check if the select peer is alive and we connect to it.
+      if (alivePeer == null) {
+      	logger.error("Cannot connect to peer node to bootstrap");
+      	return false;
+      }
+      else {   
+          logger.info("Issue slaveof command on peer[" + alivePeer + "] and port[" + REDIS_PORT + "]");
+          startPeerSync(alivePeer, REDIS_PORT);
+          
+
+          long diff = 0;
+          long previousDiff = 0;
+          short retry = 0;
+          short numErrors = 0;
+          long startTime = System.currentTimeMillis();
+          
+          /*
+           * Conditions under which warmp up will end
+           * 1. number of Jedis errors are 5.
+           * 2. number of consecutive increases of offset differences (caused when client produces high load).
+           * 3. the difference between offsets is very small or zero (success).
+           * 4. warmp up takes more than 15 minutes.
+           * 5. Dynomite has started and is healthy.
+           */
+          
+          while (numErrors < 5) {
+          	// sleep 10 seconds in between checks
+              sleeper.sleepQuietly(10000);
+              try {
+                  diff = canPeerSyncStop(peerJedis, startTime);
+              } catch (Exception e) {
+              	numErrors++;
+              }
+              
+              /*
+               * Diff meaning:
+               * a. diff ==  0 --> we are either in sync or close to sync.
+               * b. diff == -1 --> there was an error in sync process.
+               * c. diff == -2 --> offset is still zero, peer syncing has not started.
+               */
+              if (diff == 0) {
+                  // Since we are ready let us start dynProcess.
+              	try { 
+              		dynProcess.start(false);
+              	}
+              	catch (IOException ex) {
+              		logger.error("Dynomite failed to start");
+              	}
+                  // Wait for 1 second before we check dynomite status
+                  sleeper.sleepQuietly(1000);
+                  dynProcess.dynomiteCheck();
+              	break;
+              }
+              else if (diff == -1) {
+              	logger.error("There was an error in the warm up process - do NOT start Dynomite");
+              	return false;
+              }                
+              else if (diff == -2 ) {
+              	startTime = System.currentTimeMillis();
+              }
+           
+              
+              /*
+               * Exit conditions:
+               * a. retry more than 5 time continuously and if the diff is larger than the previous diff.
+               */
+              if (previousDiff < diff) {
+              	logger.info("Previous diff (" + previousDiff +") was smaller than current diff (" + diff  +") ---> Retry effort: " + retry);
+              	retry++;
+              	if (retry == 5){
+                  	logger.info("Reached 5 consecutive retries, peer syncing cannot complete");
+                  	break;
+              	}
+              }
+              else{
+              	retry = 0;
+              }
+              previousDiff = diff;
+          }
+
+          logger.info("Set Dynomite to allow writes only!!!");
+          sendCommand("/state/writes_only");
+          
+          logger.info("Stop Redis' Peer syncing!!!");
+          stopPeerSync();
+          
+          logger.info("Set Dynomite to resuming state to allow writes and flush delayed writes");
+          sendCommand("/state/resuming");
+          
+          //sleep 15s for the flushing to catch up
+          sleeper.sleepQuietly(15000);
+          logger.info("Set Dynomite to normal state");
+          sendCommand("/state/normal");
+          
+          peerJedis.disconnect();
+
+          if (diff > 0) {
+              logger.error("Peer sync can't finish!  Something is wrong.");
+              return false;
+          }
+      }
+
+      return true;
+  }
+  /**
+   * Resets Redis to master if it was slave due to warm up failure.
+   */
+  @Override
+  public boolean resetStorage() {
+  	logger.info("Checking if Redis needs to be resetted to master");
+      connect();
+      String peerRedisInfo = null;
+      try {
+      	peerRedisInfo = localJedis.info();
+      } catch (JedisConnectionException e) {
+      	// Try to reconnect
+      	try {
+      		connect();
+          	peerRedisInfo = localJedis.info();
+      	} catch (JedisConnectionException ex) {
+      		logger.error("Cannot connect to Redis");
+      		return false;
+      	}
+      }
+      Iterable<String> result = Splitter.on('\n').split(peerRedisInfo);
+      
+      String role = null;
+
+      for(String line : result) {
+          if (line.startsWith("role")) {
+              String[] items = line.split(":");
+           //   logger.info(items[0] + ": " + items[1]);
+              role = items[1].trim();
+              if(role.equals("slave")){
+              	logger.info("Redis: slave ----> master");
+              	stopPeerSync();
+              }
+              return true;
+          }
+      }
+      
+      return false;
+
+  }
+
+
+  private Long canPeerSyncStop(Jedis peerJedis, long startTime) throws RedisSyncException {
+  	
+  	if (System.currentTimeMillis() - startTime > config.getMaxTimeToBootstrap()) {
+         	logger.warn("Warm up takes more than 15 minutes --> moving on");
+         	return (long) -1;
+      }
+  	
+      logger.info("Checking for peer syncing");
+      String peerRedisInfo = peerJedis.info();
+      
+      Long masterOffset = -1L;
+      Long slaveOffset = -1L;
+      
+      //get peer's repl offset
+      Iterable<String> result = Splitter.on('\n').split(peerRedisInfo);
+      
+      for(String line : result) {
+          if (line.startsWith("master_repl_offset")) {
+              String[] items = line.split(":");
+              logger.info(items[0] + ": " + items[1]);
+              masterOffset = Long.parseLong(items[1].trim());
+              
+          }
+          
+          //slave0:ip=10.99.160.121,port=22122,state=online,offset=17279,lag=0
+          if (line.startsWith("slave0")) {
+              String[] items = line.split(",");
+              for(String item : items) {
+                  if (item.startsWith("offset")) {
+                      String[] offset = item.split("=");
+                      logger.info(offset[0] + ": " + offset[1]);
+                      slaveOffset = Long.parseLong(offset[1].trim());
+                  }           
+              }
+          }
+      }
+
+      if (slaveOffset == -1) {
+      	logger.error("Slave offset could not be parsed --> check memory overcommit configuration");
+      	return (long) -1;
+      }
+      else if (slaveOffset == 0) {
+      	logger.info("Slave offset is zero ---> Redis master node still dumps data to the disk");
+      	return (long) -2;
+      }
+      Long diff = Math.abs(masterOffset - slaveOffset);
+      
+      logger.info("masterOffset: " + masterOffset + " slaveOffset: " + slaveOffset + 
+      		" current Diff: " + diff + 
+      		" allowable diff: " + config.getAllowableBytesSyncDiff());
+      /* 
+       * Allowable bytes sync diff can be configured by a Fast Property.
+       * If the difference is very small, then we return zero.
+       */
+      if (diff < config.getAllowableBytesSyncDiff()) {
+          logger.info("master and slave are in sync!");
+          return (long) 0;
+      }
+      else if (slaveOffset == 0) {
+      	logger.info("slave has not started syncing");
+      }
+      return diff;
+  }
+  
+  private class RedisSyncException extends Exception {
+       public RedisSyncException(String msg) {
+           super(msg);
+       }
+  }
+  
+  private boolean sendCommand(String cmd) {
+      String url = adminUrl.get() + cmd;
+      HttpClient client = new HttpClient();
+      client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, 
+                                      new DefaultHttpMethodRetryHandler());
+      
+      GetMethod get = new GetMethod(url);
+      try {
+          int statusCode = client.executeMethod(get);
+          if (!(statusCode == 200)) {
+              logger.error("Got non 200 status code from " + url);
+              return false;
+          }
+          
+          String response = get.getResponseBodyAsString();
+          //logger.info("Received response from " + url + "\n" + response);
+          
+          if (!response.isEmpty()) {
+              logger.info("Received response from " + url + "\n" + response);
+          } else {
+              logger.error("Cannot parse empty response from " + url);
+              return false;
+          }
+          
+      } catch (Exception e) {
+          logger.error("Failed to sendCommand and invoke url: " + url, e);
+          return false;
+      }
+      
+      return true;
+  }
 
 }

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -1,8 +1,8 @@
 ## Application info
 netflix.datacenter=cloud
-netflix.appinfo.statusPageUrl=http://${netflix.appinfo.hostname}:8080/Status
+netflix.appinfo.statusPageUrl=http://${netflix.appinfo.hostname}:8080/REST/v1/admin/Status
 netflix.appinfo.homePageUrl=http://${netflix.appinfo.hostname}:8080/Status
-netflix.appinfo.healthCheckUrl=http://${netflix.appinfo.hostname}:8080/REST/healthcheck
+netflix.appinfo.healthCheckUrl=http://${netflix.appinfo.hostname}:8080/REST/healthchecksss
 netflix.appinfo.port=7001
 
 


### PR DESCRIPTION
This PR does two things:
(a) enhances the warm up process by
* delaying the start of Dynomite. We do not need to start Dynomite before the warm up finishes. The reason is that replicated data are received by peer nodes even though the node is out of Discovery. That may increase the memory footprint of Dynomite.
* asking the local rack for the nodes with the same token

(b) adds a REST endpoint in Florida in which you can find information about the status of the node in JSON format. The reason, we added this feature is:
to have a single point of ground truth about the node without having to parse logs (especially useful for S3 backups). It will allow us to check before we move on.
For now, the following are supported:
* warmup (status: not started, completed, pending, unsuccessful)
* backup (status: not started, completed, pending, unsuccessful)
* restore (status: not started, completed, pending, unsuccessful)
* dynomiteAlive
* storageAlive
* healthy

(c) restructured backups and restores so that we can extend them to other platforms as well. The main benefit from that would be OSS folks who use Dynomite-manager with Google Cloud etc.