### PR TITLE
force warm up, select oldest node for warm up, YAML persist

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
@@ -50,7 +50,6 @@ public class FloridaServer
     private final InstanceIdentity id;
     private final Sleeper sleeper;
     private final TuneTask tuneTask;
-    private final ProcessMonitorTask processMonitorTask;
     private final IFloridaProcess dynProcess;
     private final InstanceState state;
     private static final Logger logger = LoggerFactory.getLogger(FloridaServer.class);
@@ -58,14 +57,13 @@ public class FloridaServer
     @Inject
     public FloridaServer(IConfiguration config, TaskScheduler scheduler,
                          InstanceIdentity id, Sleeper sleeper, TuneTask tuneTask,
-                         ProcessMonitorTask processMonitorTask, InstanceState state, IFloridaProcess dynProcess)
+                         InstanceState state, IFloridaProcess dynProcess)
     {
         this.config = config;
         this.scheduler = scheduler;
         this.id = id;
         this.sleeper = sleeper;
         this.tuneTask = tuneTask;
-        this.processMonitorTask = processMonitorTask;
         this.state = state;
         this.dynProcess = dynProcess;
         
@@ -115,7 +113,10 @@ public class FloridaServer
     		logger.info("Restore is disabled.");
 
     		// Boostraping only if this is a new node.
-    		if (config.isWarmBootstrap() && id.isReplace()){
+    		if (config.isForceWarm() || (config.isWarmBootstrap() && id.isReplace())){
+    			if (config.isForceWarm()){
+    				logger.info("Enforcing warm up.");
+    			}
     			logger.info("Warm bootstraping node. Scheduling BootstrapTask now!");
     			dynProcess.stop();
     			scheduler.runTaskNow(WarmBootstrapTask.class);

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/IInstanceState.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/IInstanceState.java
@@ -1,0 +1,13 @@
+package com.netflix.dynomitemanager;
+
+public interface IInstanceState {
+	
+	public boolean isSideCarProcessAlive();
+	
+	public boolean isBootstrapping();
+	
+	public boolean getYmlWritten();
+
+	public void setYmlWritten(boolean b);
+		
+}

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InstanceState.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InstanceState.java
@@ -29,7 +29,7 @@ import org.joda.time.DateTime;
  *
  */
 @Singleton
-public class InstanceState {
+public class InstanceState implements IInstanceState {
     private final AtomicBoolean isSideCarProcessAlive = new AtomicBoolean(false);
     private final AtomicBoolean isBootstrapping = new AtomicBoolean(false);
     private final AtomicBoolean firstBootstrap = new AtomicBoolean(true);
@@ -48,6 +48,9 @@ public class InstanceState {
     private long bootstrapTime;
     private long backupTime;
     private long restoreTime;
+    
+    private final AtomicBoolean isYmlWritten = new AtomicBoolean(false);
+
     
     // This is true if storage proxy and storage are alive.
     private final AtomicBoolean isHealthy = new AtomicBoolean(false);
@@ -252,6 +255,14 @@ public class InstanceState {
     //@Monitor(name="processMonitoringSuspended", type=DataSourceType.GAUGE)
     public int metricIsProcessMonitoringSuspended() {
         return getIsProcessMonitoringSuspended() ? 1 : 0;
+    }
+    
+    public boolean getYmlWritten(){
+    	return this.isYmlWritten.get();
+    }
+    
+    public void setYmlWritten(boolean yml){
+    	this.isYmlWritten.set(yml);
     }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -111,6 +111,7 @@ public class DynomitemanagerConfiguration implements IConfiguration
     private static final String CONFIG_DYNO_WRITE_CONS                 = DYNOMITEMANAGER_PRE + ".dyno.write.consistency";
     
     // warm up
+    private static final String CONFIG_DYNO_WARM_FORCE				   = DYNOMITEMANAGER_PRE + ".dyno.warm.force";
     private static final String CONFIG_DYNO_WARM_BOOTSTRAP             = DYNOMITEMANAGER_PRE + ".dyno.warm.bootstrap";
     private static final String CONFIG_DYNO_ALLOWABLE_BYTES_SYNC_DIFF  = DYNOMITEMANAGER_PRE + ".dyno.warm.bytes.sync.diff";
     private static final String CONFIG_DYNO_MAX_TIME_BOOTSTRAP		   = DYNOMITEMANAGER_PRE + ".dyno.warm.msec.bootstraptime";
@@ -315,13 +316,11 @@ public class DynomitemanagerConfiguration implements IConfiguration
     {
         private static final int NUMBER_OF_RETRIES = 15;
         private static final long WAIT_TIME = 30000;
-        private final String region;
         private final String instanceId;
         private final AmazonEC2 client;
         
         public GetASGName(String region, String instanceId) {
             super(NUMBER_OF_RETRIES, WAIT_TIME);
-            this.region = region;
             this.instanceId = instanceId;
             client = new AmazonEC2Client(provider.getAwsCredentialProvider());
             client.setEndpoint("ec2." + region + ".amazonaws.com");
@@ -587,6 +586,10 @@ public class DynomitemanagerConfiguration implements IConfiguration
    
     public boolean isWarmBootstrap() {
         return configSource.get(CONFIG_DYNO_WARM_BOOTSTRAP, false);
+    }
+    
+    public boolean isForceWarm() {
+    	return configSource.get(CONFIG_DYNO_WARM_FORCE, false);
     }
     
 	public int getAllowableBytesSyncDiff() {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
@@ -167,6 +167,8 @@ public interface IConfiguration
 	
 	public boolean isWarmBootstrap();
 	
+	public boolean isForceWarm();
+	
 	public boolean isHealthCheckEnable();
 	
 	public int getAllowableBytesSyncDiff();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/utils/TuneTask.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/utils/TuneTask.java
@@ -48,8 +48,9 @@ public class TuneTask extends Task
         return "Tune-Task";
     }
 
+    // update the YML every 60 seconds.
     public static TaskTimer getTimer()
     {
-        return new SimpleTimer(JOBNAME);
+        return new SimpleTimer(JOBNAME, 60L * 1000);
     }
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FakeInstanceState.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FakeInstanceState.java
@@ -1,0 +1,36 @@
+package com.netflix.dynomitemanager.defaultimpl.test;
+
+import com.netflix.dynomitemanager.IInstanceState;
+
+/**
+ * 
+ * Unit Tests for FakeInstanceState
+ * 
+ * @author ipapapa
+ *
+ */
+
+public class FakeInstanceState implements IInstanceState {
+
+	@Override
+	public boolean isSideCarProcessAlive() {
+		return false;
+	}
+
+	@Override
+	public boolean isBootstrapping() {
+		return false;
+	}
+
+	@Override
+	public boolean getYmlWritten() {
+		return false;
+	}
+
+	@Override
+	public void setYmlWritten(boolean b) {
+		// TODO Auto-generated method stub
+		
+	}
+
+}

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FloridaStandardTunerTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FloridaStandardTunerTest.java
@@ -33,13 +33,15 @@ import com.netflix.dynomitemanager.monitoring.test.BlankConfiguration;
  * Unit Tests for FloridaStandardTuner
  * 
  * @author diegopacheco
+ * @author ipapapa
  *
  */
 public class FloridaStandardTunerTest {
 	
 	@Test
 	public void testWriteAllProperties() throws Exception{
-		FloridaStandardTuner tuner = new FloridaStandardTuner(new BlankConfiguration(), new FakeInstanceIdentity());
+		//TODO: we need to a FakeInstanceState in the future.
+		FloridaStandardTuner tuner = new FloridaStandardTuner(new BlankConfiguration(), new FakeInstanceIdentity(), new FakeInstanceState());
 		
 		String yamlPath         = System.getProperty("java.io.tmpdir") + "/yaml-tunner.yaml";
 		String templateYamlPath = new File(".").getCanonicalPath() + "/src/test/resources/sample-yaml.yaml";

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -23,6 +23,7 @@ import com.netflix.dynomitemanager.sidecore.IConfiguration;
  * IConfiguration implementation for tests.
  * 
  * @author diegopacheco
+ * @author ipapapa
  *
  */
 public class SimpleTestConfiguration implements IConfiguration {
@@ -353,6 +354,11 @@ public class SimpleTestConfiguration implements IConfiguration {
 
 	@Override
 	public boolean isDualAccount() {
+		return false;
+	}
+
+	@Override
+	public boolean isForceWarm() {
 		return false;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -20,9 +20,10 @@ import java.util.List;
 import com.netflix.dynomitemanager.sidecore.IConfiguration;
 
 /**
- * Blanck IConfiguration class used for tests.
+ * Blank IConfiguration class used for tests.
  * 
  * @author diegopacheco
+ * @author ipapapa
  *
  */
 public class BlankConfiguration implements IConfiguration {
@@ -353,6 +354,12 @@ public class BlankConfiguration implements IConfiguration {
 
 	@Override
 	public boolean isDualAccount() {
+		return false;
+	}
+
+	@Override
+	public boolean isForceWarm() {
+		// TODO Auto-generated method stub
 		return false;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -359,7 +359,6 @@ public class BlankConfiguration implements IConfiguration {
 
 	@Override
 	public boolean isForceWarm() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 


### PR DESCRIPTION
* Adding support to persist the YAML file whenever there is change in the seeds. This is important as when we manually restart Dynomite in a node, we may end up not getting the most updated seeds. Now manually restarting Dynomite would read the YAML pick up the correct seeds.
* Adding support to force warmup. This is handy when Redis process dies, or is accidentally killed. Setting a fast property to force warm up, a restart of Dynomite Manager will warm up the node. 
* Enhancing warm up by selecting the oldest node among the alive candidates with the same token. This will increase the accuracy of data after a node termination.