### PR TITLE
Adding random sleeping time

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/FloridaServer.java
@@ -14,7 +14,6 @@ package com.netflix.dynomitemanager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.collections.CollectionUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -36,140 +35,148 @@ import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.monitor.Monitors;
 
 /**
- * Start the Dynomite Manager (DM) server, set DM's status and start the following tasks:
+ * Start the Dynomite Manager (DM) server, set DM's status and start the
+ * following tasks:
  *
  * <ul>
- * <li>{@link com.netflix.dynomitemanager.sidecore.aws.UpdateSecuritySettings}: In a multi-DC deployment, update the AWS
- * security group (SG) inbound traffic filters.
- * <li>{@link com.netflix.dynomitemanager.sidecore.utils.TuneTask}: Write the dynomite.yaml configuration file.
- * <li>{@link com.netflix.dynomitemanager.sidecore.backup.RestoreTask}: If restore mode, then restore data from an
- * object store (i.e. S3).
- * <li>{@link com.netflix.dynomitemanager.sidecore.utils.WarmBootstrapTask}: If warm bootstrap mode, then warm the
- * storage backend by syncing data from a peer.
- * <li>{@link com.netflix.dynomitemanager.sidecore.utils.ProxyAndStorageResetTask}: If cold bootstrap mode, then stop
- * any in progress sync, reset storage backend to master, and restart dynomite proxy (if necessary).
- * <li>{@link com.netflix.dynomitemanager.sidecore.backup.SnapshotTask}: If backups are enabled, then add the backup
- * snapshot task.
- * <li>{@link com.netflix.dynomitemanager.monitoring.ServoMetricsTask}: Publish metrics via Servo.
- * <li>{@link com.netflix.dynomitemanager.monitoring.RedisInfoMetricsTask}: Update metrics obtained via Redis INFO
- * command.
- * <li>{@link com.netflix.dynomitemanager.sidecore.utils.ProcessMonitorTask}: Monitor the dynomite and redis-server
- * processes, and restart as necessary.
+ * <li>{@link com.netflix.dynomitemanager.sidecore.aws.UpdateSecuritySettings}:
+ * In a multi-DC deployment, update the AWS security group (SG) inbound traffic
+ * filters.
+ * <li>{@link com.netflix.dynomitemanager.sidecore.utils.TuneTask}: Write the
+ * dynomite.yaml configuration file.
+ * <li>{@link com.netflix.dynomitemanager.sidecore.backup.RestoreTask}: If
+ * restore mode, then restore data from an object store (i.e. S3).
+ * <li>{@link com.netflix.dynomitemanager.sidecore.utils.WarmBootstrapTask}: If
+ * warm bootstrap mode, then warm the storage backend by syncing data from a
+ * peer.
+ * <li>{@link com.netflix.dynomitemanager.sidecore.utils.ProxyAndStorageResetTask}:
+ * If cold bootstrap mode, then stop any in progress sync, reset storage backend
+ * to master, and restart dynomite proxy (if necessary).
+ * <li>{@link com.netflix.dynomitemanager.sidecore.backup.SnapshotTask}: If
+ * backups are enabled, then add the backup snapshot task.
+ * <li>{@link com.netflix.dynomitemanager.monitoring.ServoMetricsTask}: Publish
+ * metrics via Servo.
+ * <li>{@link com.netflix.dynomitemanager.monitoring.RedisInfoMetricsTask}:
+ * Update metrics obtained via Redis INFO command.
+ * <li>{@link com.netflix.dynomitemanager.sidecore.utils.ProcessMonitorTask}:
+ * Monitor the dynomite and redis-server processes, and restart as necessary.
  * </ul>
  */
 @Singleton
 public class FloridaServer {
-	private final TaskScheduler scheduler;
-	private final IConfiguration config;
-	private final InstanceIdentity id;
-	private final Sleeper sleeper;
-	private final TuneTask tuneTask;
-	private final IFloridaProcess dynProcess;
-	private final InstanceState state;
-	private static final Logger logger = LoggerFactory.getLogger(FloridaServer.class);
+    private final TaskScheduler scheduler;
+    private final IConfiguration config;
+    private final InstanceIdentity id;
+    private final Sleeper sleeper;
+    private final TuneTask tuneTask;
+    private final IFloridaProcess dynProcess;
+    private final InstanceState state;
+    private static final Logger logger = LoggerFactory.getLogger(FloridaServer.class);
 
-	@Inject
-	public FloridaServer(IConfiguration config, TaskScheduler scheduler, InstanceIdentity id, Sleeper sleeper,
-			TuneTask tuneTask, InstanceState state, IFloridaProcess dynProcess) {
+    @Inject
+    public FloridaServer(IConfiguration config, TaskScheduler scheduler, InstanceIdentity id, Sleeper sleeper,
+	    TuneTask tuneTask, InstanceState state, IFloridaProcess dynProcess) {
 
-		this.config = config;
-		this.scheduler = scheduler;
-		this.id = id;
-		this.sleeper = sleeper;
-		this.tuneTask = tuneTask;
-		this.state = state;
-		this.dynProcess = dynProcess;
+	this.config = config;
+	this.scheduler = scheduler;
+	this.id = id;
+	this.sleeper = sleeper;
+	this.tuneTask = tuneTask;
+	this.state = state;
+	this.dynProcess = dynProcess;
 
-		DefaultMonitorRegistry.getInstance().register(Monitors.newObjectMonitor(state));
+	DefaultMonitorRegistry.getInstance().register(Monitors.newObjectMonitor(state));
 
+    }
+
+    /**
+     * Start Dynomite Manager.
+     * 
+     * @throws Exception
+     */
+    public void initialize() throws Exception {
+	if (id.getInstance().isOutOfService())
+	    return;
+
+	logger.info("Initializing Dynomite Manager now ...");
+
+	state.setSideCarProcessAlive(true);
+	state.setBootstrapStatus(Bootstrap.NOT_STARTED);
+
+	if (config.isMultiRegionedCluster()) {
+	    scheduler.runTaskNow(UpdateSecuritySettings.class);
+	    if (id.isReplace() || id.isTokenPregenerated()) {
+		long initTime = 100 + (int) (Math.random() * ((200 - 100) + 1));
+
+		logger.info("Sleeping " + initTime + "seconds -> a node is replaced or token is pregenerated.");
+		sleeper.sleep(initTime * 1000);
+	    } else if (UpdateSecuritySettings.firstTimeUpdated) {
+		logger.info("Sleeping 60 seconds -> first time security settings are updated");
+		sleeper.sleep(60 * 1000);
+	    }
+
+	    scheduler.addTask(UpdateSecuritySettings.JOBNAME, UpdateSecuritySettings.class,
+		    UpdateSecuritySettings.getTimer(id));
 	}
 
-	/**
-	 * Start Dynomite Manager.
-	 * @throws Exception
-	 */
-	public void initialize() throws Exception {
-		if (id.getInstance().isOutOfService())
-			return;
+	// scheduler.runTaskNow(TuneTask.class);
+	// Invoking the task directly as any errors in this task
+	// should not let Florida continue. However, we don't want to kill
+	// the Florida process, but, want it to be stuck.
+	logger.info("Running TuneTask and updating configuration.");
+	tuneTask.execute();
 
-		logger.info("Initializing Dynomite Manager now ...");
+	// Determine if we need to restore from backup else start Dynomite.
+	if (config.isRestoreEnabled()) {
+	    logger.info("Restore is enabled.");
+	    scheduler.runTaskNow(RestoreTask.class); // restore from the AWS
+	    logger.info("Scheduled task " + RestoreTask.TaskName);
+	} else { // no restores needed
+	    logger.info("Restore is disabled.");
 
-		state.setSideCarProcessAlive(true);
-		state.setBootstrapStatus(Bootstrap.NOT_STARTED);
-
-		if (config.isMultiRegionedCluster()) {
-			scheduler.runTaskNow(UpdateSecuritySettings.class);
-			// sleep for 130 sec if this is a new node with new IP for SG to be updated by other seed nodes
-			if (id.isReplace() || id.isTokenPregenerated()) {
-				logger.info("Sleeping 130 seconds -> a node is replaced or token is pregenerated.");
-				sleeper.sleep(130 * 1000);
-			} else if (UpdateSecuritySettings.firstTimeUpdated) {
-				logger.info("Sleeping 60 seconds -> first time security settings are updated");
-				sleeper.sleep(60 * 1000);
-			}
-
-			scheduler.addTask(UpdateSecuritySettings.JOBNAME, UpdateSecuritySettings.class,
-					UpdateSecuritySettings.getTimer(id));
+	    // Bootstrapping only if this is a new node.
+	    if (config.isForceWarm() || (config.isWarmBootstrap() && id.isReplace())) {
+		if (config.isForceWarm()) {
+		    logger.info("Enforcing warm up.");
 		}
-
-		//    	scheduler.runTaskNow(TuneTask.class);
-		// Invoking the task directly as any errors in this task
-		// should not let Florida continue. However, we don't want to kill
-		// the Florida process, but, want it to be stuck.
-		logger.info("Running TuneTask and updating configuration.");
-		tuneTask.execute();
-
-		// Determine if we need to restore from backup else start Dynomite.
-		if (config.isRestoreEnabled()) {
-			logger.info("Restore is enabled.");
-			scheduler.runTaskNow(RestoreTask.class); //restore from the AWS
-			logger.info("Scheduled task " + RestoreTask.TaskName);
-		} else { //no restores needed
-			logger.info("Restore is disabled.");
-
-			// Bootstrapping only if this is a new node.
-			if (config.isForceWarm() || (config.isWarmBootstrap() && id.isReplace())) {
-				if (config.isForceWarm()) {
-					logger.info("Enforcing warm up.");
-				}
-				logger.info("Warm bootstrapping node. Scheduling BootstrapTask now!");
-				dynProcess.stop();
-				scheduler.runTaskNow(WarmBootstrapTask.class);
-			} else {
-				logger.info("Cold bootstrapping, launching dynomite and storage process.");
-				dynProcess.start();
-				sleeper.sleepQuietly(1000); //1s
-				scheduler.runTaskNow(ProxyAndStorageResetTask.class);
-			}
-		}
-
-		// Backup
-		if (config.isBackupEnabled() && config.getBackupHour() >= 0) {
-			scheduler.addTask(SnapshotTask.TaskName, SnapshotTask.class, SnapshotTask.getTimer(config));
-		}
-
-		// Metrics
-		scheduler.addTask(ServoMetricsTask.TaskName, ServoMetricsTask.class, ServoMetricsTask.getTimer());
-		scheduler.addTask(RedisInfoMetricsTask.TaskName, RedisInfoMetricsTask.class,
-				RedisInfoMetricsTask.getTimer());
-
-		// Routine monitoring and restarting dynomite or storage processes as needed.
-		scheduler.addTask(ProcessMonitorTask.JOBNAME, ProcessMonitorTask.class, ProcessMonitorTask.getTimer());
-
-		logger.info("Starting task scheduler");
-		scheduler.start();
+		logger.info("Warm bootstrapping node. Scheduling BootstrapTask now!");
+		dynProcess.stop();
+		scheduler.runTaskNow(WarmBootstrapTask.class);
+	    } else {
+		logger.info("Cold bootstrapping, launching dynomite and storage process.");
+		dynProcess.start();
+		sleeper.sleepQuietly(1000); // 1s
+		scheduler.runTaskNow(ProxyAndStorageResetTask.class);
+	    }
 	}
 
-	public InstanceIdentity getId() {
-		return id;
+	// Backup
+	if (config.isBackupEnabled() && config.getBackupHour() >= 0) {
+	    scheduler.addTask(SnapshotTask.TaskName, SnapshotTask.class, SnapshotTask.getTimer(config));
 	}
 
-	public TaskScheduler getScheduler() {
-		return scheduler;
-	}
+	// Metrics
+	scheduler.addTask(ServoMetricsTask.TaskName, ServoMetricsTask.class, ServoMetricsTask.getTimer());
+	scheduler.addTask(RedisInfoMetricsTask.TaskName, RedisInfoMetricsTask.class, RedisInfoMetricsTask.getTimer());
 
-	public IConfiguration getConfiguration() {
-		return config;
-	}
+	// Routine monitoring and restarting dynomite or storage processes as
+	// needed.
+	scheduler.addTask(ProcessMonitorTask.JOBNAME, ProcessMonitorTask.class, ProcessMonitorTask.getTimer());
+
+	logger.info("Starting task scheduler");
+	scheduler.start();
+    }
+
+    public InstanceIdentity getId() {
+	return id;
+    }
+
+    public TaskScheduler getScheduler() {
+	return scheduler;
+    }
+
+    public IConfiguration getConfiguration() {
+	return config;
+    }
 
 }


### PR DESCRIPTION
If a large number of nodes starts together then the opportunistic row lock provided by the Astyanax library may fail. In this case, multiple nodes will try to store the tokens in the Cassandra cluster, resulting in an incorrect token topology. By adding a random sleep time when a new token is generated, we decrease the competition.