### PR TITLE
enhanced cross account when bringing up a new cluster

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/IInstanceState.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/IInstanceState.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dynomitemanager;
 
 public interface IInstanceState {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -38,691 +38,702 @@ import com.netflix.dynomitemanager.sidecore.utils.RetryableCallable;
 import com.netflix.dynomitemanager.identity.InstanceEnvIdentity;
 
 /**
- * Define the list of available Dynomite Manager configuration options, then set options based on the environment and
- * an external configuration.
+ * Define the list of available Dynomite Manager configuration options, then set
+ * options based on the environment and an external configuration.
  */
 @Singleton
 public class DynomitemanagerConfiguration implements IConfiguration {
-	public static final String DYNOMITEMANAGER_PRE = "florida";
+    public static final String DYNOMITEMANAGER_PRE = "florida";
 
-	public static final int DYNO_MEMCACHED = 0;
-	public static final int DYNO_REDIS = 1;
-	public static final String DYNO_REDIS_CONF_PATH = "/apps/nfredis/conf/redis.conf";
-	public static final int DYNO_PORT = 8102;
-	public static final int REDIS_PORT = 22122;
-	public final static String LOCAL_ADDRESS = "127.0.0.1";
+    public static final int DYNO_MEMCACHED = 0;
+    public static final int DYNO_REDIS = 1;
+    public static final String DYNO_REDIS_CONF_PATH = "/apps/nfredis/conf/redis.conf";
+    public static final int DYNO_PORT = 8102;
+    public static final int REDIS_PORT = 22122;
+    public final static String LOCAL_ADDRESS = "127.0.0.1";
 
-	private static final String CONFIG_DYN_HOME_DIR = DYNOMITEMANAGER_PRE + ".dyno.home";
-	private static final String CONFIG_DYN_START_SCRIPT = DYNOMITEMANAGER_PRE + ".dyno.startscript";
-	private static final String CONFIG_DYN_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".dyno.stopscript";
+    private static final String CONFIG_DYN_HOME_DIR = DYNOMITEMANAGER_PRE + ".dyno.home";
+    private static final String CONFIG_DYN_START_SCRIPT = DYNOMITEMANAGER_PRE + ".dyno.startscript";
+    private static final String CONFIG_DYN_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".dyno.stopscript";
 
-	private static final String CONFIG_CLUSTER_NAME = DYNOMITEMANAGER_PRE + ".dyno.clustername";
-	private static final String CONFIG_SEED_PROVIDER_NAME = DYNOMITEMANAGER_PRE + ".dyno.seed.provider";
-	private static final String CONFIG_DYN_LISTENER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.port";
-	private static final String CONFIG_DYN_PEER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.peer.port";
-	private static final String CONFIG_DYN_SECURED_PEER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.secured.peer.port";
-	private static final String CONFIG_RACK_NAME = DYNOMITEMANAGER_PRE + ".dyno.rack";
-	private static final String CONFIG_USE_ASG_FOR_RACK_NAME = DYNOMITEMANAGER_PRE + ".dyno.asg.rack";
-	private static final String CONFIG_TOKENS_DISTRIBUTION_NAME = DYNOMITEMANAGER_PRE + ".dyno.tokens.distribution";
-	private static final String CONFIG_DYNO_REQ_TIMEOUT_NAME =
-			DYNOMITEMANAGER_PRE + ".dyno.request.timeout";   //in milliseconds
-	private static final String CONFIG_DYNO_GOSSIP_INTERVAL_NAME =
-			DYNOMITEMANAGER_PRE + ".dyno.gossip.interval"; //in milliseconds
-	private static final String CONFIG_DYNO_TOKENS_HASH_NAME = DYNOMITEMANAGER_PRE + ".dyno.tokens.hash";
-	private static final String CONFIG_DYNO_CONNECTIONS_PRECONNECT =
-			DYNOMITEMANAGER_PRE + ".dyno.connections.preconnect";
-	private static final String CONFIG_DYNO_CLUSTER_TYPE = DYNOMITEMANAGER_PRE + ".dyno.cluster.type";
-	private static final String CONFIG_DYNO_IS_MULTI_REGIONED_CLUSTER = DYNOMITEMANAGER_PRE + ".dyno.multiregion";
-	private static final String CONFIG_DYNO_HEALTHCHECK_ENABLE = DYNOMITEMANAGER_PRE + ".dyno.healthcheck.enable";
-	// The max percentage of system memory to be allocated to the Dynomite fronted data store.
-	private static final String CONFIG_DYNO_STORAGE_MEM_PCT_INT = DYNOMITEMANAGER_PRE + ".dyno.storage.mem.pct.int";
+    private static final String CONFIG_CLUSTER_NAME = DYNOMITEMANAGER_PRE + ".dyno.clustername";
+    private static final String CONFIG_SEED_PROVIDER_NAME = DYNOMITEMANAGER_PRE + ".dyno.seed.provider";
+    private static final String CONFIG_DYN_LISTENER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.port";
+    private static final String CONFIG_DYN_PEER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.peer.port";
+    private static final String CONFIG_DYN_SECURED_PEER_PORT_NAME = DYNOMITEMANAGER_PRE + ".dyno.secured.peer.port";
+    private static final String CONFIG_RACK_NAME = DYNOMITEMANAGER_PRE + ".dyno.rack";
+    private static final String CONFIG_USE_ASG_FOR_RACK_NAME = DYNOMITEMANAGER_PRE + ".dyno.asg.rack";
+    private static final String CONFIG_TOKENS_DISTRIBUTION_NAME = DYNOMITEMANAGER_PRE + ".dyno.tokens.distribution";
+    private static final String CONFIG_DYNO_REQ_TIMEOUT_NAME = DYNOMITEMANAGER_PRE + ".dyno.request.timeout"; // in
+													      // milliseconds
+    private static final String CONFIG_DYNO_GOSSIP_INTERVAL_NAME = DYNOMITEMANAGER_PRE + ".dyno.gossip.interval"; // in
+														  // milliseconds
+    private static final String CONFIG_DYNO_TOKENS_HASH_NAME = DYNOMITEMANAGER_PRE + ".dyno.tokens.hash";
+    private static final String CONFIG_DYNO_CONNECTIONS_PRECONNECT = DYNOMITEMANAGER_PRE
+	    + ".dyno.connections.preconnect";
+    private static final String CONFIG_DYNO_CLUSTER_TYPE = DYNOMITEMANAGER_PRE + ".dyno.cluster.type";
+    private static final String CONFIG_DYNO_IS_MULTI_REGIONED_CLUSTER = DYNOMITEMANAGER_PRE + ".dyno.multiregion";
+    private static final String CONFIG_DYNO_HEALTHCHECK_ENABLE = DYNOMITEMANAGER_PRE + ".dyno.healthcheck.enable";
+    // The max percentage of system memory to be allocated to the Dynomite
+    // fronted data store.
+    private static final String CONFIG_DYNO_STORAGE_MEM_PCT_INT = DYNOMITEMANAGER_PRE + ".dyno.storage.mem.pct.int";
 
-	private static final String CONFIG_DYNO_MBUF_SIZE = DYNOMITEMANAGER_PRE + ".dyno.mbuf.size";
-	private static final String CONFIG_DYNO_MAX_ALLOC_MSGS = DYNOMITEMANAGER_PRE + ".dyno.allocated.messages";
+    private static final String CONFIG_DYNO_MBUF_SIZE = DYNOMITEMANAGER_PRE + ".dyno.mbuf.size";
+    private static final String CONFIG_DYNO_MAX_ALLOC_MSGS = DYNOMITEMANAGER_PRE + ".dyno.allocated.messages";
 
-	private static final String CONFIG_AVAILABILITY_ZONES = DYNOMITEMANAGER_PRE + ".zones.available";
-	private static final String CONFIG_AVAILABILITY_RACKS = DYNOMITEMANAGER_PRE + ".racks.available";
+    private static final String CONFIG_AVAILABILITY_ZONES = DYNOMITEMANAGER_PRE + ".zones.available";
+    private static final String CONFIG_AVAILABILITY_RACKS = DYNOMITEMANAGER_PRE + ".racks.available";
 
-	private static final String CONFIG_DYN_PROCESS_NAME = DYNOMITEMANAGER_PRE + ".dyno.processname";
-	private static final String CONFIG_YAML_LOCATION = DYNOMITEMANAGER_PRE + ".yamlLocation";
-	private static final String CONFIG_METADATA_KEYSPACE = DYNOMITEMANAGER_PRE + ".metadata.keyspace";
-	private static final String CONFIG_SECURED_OPTION = DYNOMITEMANAGER_PRE + ".secured.option";
-	private static final String CONFIG_DYNO_AUTO_EJECT_HOSTS = DYNOMITEMANAGER_PRE + ".auto.eject.hosts";
+    private static final String CONFIG_DYN_PROCESS_NAME = DYNOMITEMANAGER_PRE + ".dyno.processname";
+    private static final String CONFIG_YAML_LOCATION = DYNOMITEMANAGER_PRE + ".yamlLocation";
+    private static final String CONFIG_METADATA_KEYSPACE = DYNOMITEMANAGER_PRE + ".metadata.keyspace";
+    private static final String CONFIG_SECURED_OPTION = DYNOMITEMANAGER_PRE + ".secured.option";
+    private static final String CONFIG_DYNO_AUTO_EJECT_HOSTS = DYNOMITEMANAGER_PRE + ".auto.eject.hosts";
 
-	// Cassandra Cluster for token management
-	private static final String CONFIG_BOOTCLUSTER_NAME = DYNOMITEMANAGER_PRE + ".bootcluster";
-	private static final String CONFIG_CASSANDRA_KEYSPACE_NAME = DYNOMITEMANAGER_PRE + ".cassandra.keyspace.name";
-	private static final String CONFIG_CASSANDRA_THRIFT_PORT = DYNOMITEMANAGER_PRE + ".cassandra.thrift.port";
-	private static final String CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES =
-			DYNOMITEMANAGER_PRE + ".cassandra.comma.separated.hostnames";
+    // Cassandra Cluster for token management
+    private static final String CONFIG_BOOTCLUSTER_NAME = DYNOMITEMANAGER_PRE + ".bootcluster";
+    private static final String CONFIG_CASSANDRA_KEYSPACE_NAME = DYNOMITEMANAGER_PRE + ".cassandra.keyspace.name";
+    private static final String CONFIG_CASSANDRA_THRIFT_PORT = DYNOMITEMANAGER_PRE + ".cassandra.thrift.port";
+    private static final String CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = DYNOMITEMANAGER_PRE
+	    + ".cassandra.comma.separated.hostnames";
 
-	// Eureka
-	private static final String CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED =
-			DYNOMITEMANAGER_PRE + ".eureka.host.supplier.enabled";
+    // Eureka
+    private static final String CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED = DYNOMITEMANAGER_PRE
+	    + ".eureka.host.supplier.enabled";
 
-	// Amazon specific
-	private static final String CONFIG_ASG_NAME = DYNOMITEMANAGER_PRE + ".az.asgname";
-	private static final String CONFIG_REGION_NAME = DYNOMITEMANAGER_PRE + ".az.region";
-	private static final String CONFIG_ACL_GROUP_NAME = DYNOMITEMANAGER_PRE + ".acl.groupname";
-	private static final String CONFIG_VPC = DYNOMITEMANAGER_PRE + ".vpc";
-	private static final String CONFIG_EC2_ROLE_ASSUMPTION_ARN = DYNOMITEMANAGER_PRE + ".ec2.roleassumption.arn";
-	private static final String CONFIG_VPC_ROLE_ASSUMPTION_ARN = DYNOMITEMANAGER_PRE + ".vpc.roleassumption.arn";
-	private static final String CONFIG_DUAL_ACCOUNT = DYNOMITEMANAGER_PRE + ".roleassumption.dualaccount";
+    // Amazon specific
+    private static final String CONFIG_ASG_NAME = DYNOMITEMANAGER_PRE + ".az.asgname";
+    private static final String CONFIG_REGION_NAME = DYNOMITEMANAGER_PRE + ".az.region";
+    private static final String CONFIG_ACL_GROUP_NAME = DYNOMITEMANAGER_PRE + ".acl.groupname";
+    private static final String CONFIG_VPC = DYNOMITEMANAGER_PRE + ".vpc";
 
-	// Dynomite Consistency
-	private static final String CONFIG_DYNO_READ_CONS = DYNOMITEMANAGER_PRE + ".dyno.read.consistency";
-	private static final String CONFIG_DYNO_WRITE_CONS = DYNOMITEMANAGER_PRE + ".dyno.write.consistency";
+    // Dual Account
+    private static final String CONFIG_EC2_ROLE_ASSUMPTION_ARN = DYNOMITEMANAGER_PRE + ".ec2.roleassumption.arn";
+    private static final String CONFIG_VPC_ROLE_ASSUMPTION_ARN = DYNOMITEMANAGER_PRE + ".vpc.roleassumption.arn";
+    private static final String CONFIG_DUAL_ACCOUNT = DYNOMITEMANAGER_PRE + ".roleassumption.dualaccount";
+    private static final String CONFIG_DUAL_ACCOUNT_AZ = DYNOMITEMANAGER_PRE + ".roleassumption.az";
+    
+    // Dynomite Consistency
+    private static final String CONFIG_DYNO_READ_CONS = DYNOMITEMANAGER_PRE + ".dyno.read.consistency";
+    private static final String CONFIG_DYNO_WRITE_CONS = DYNOMITEMANAGER_PRE + ".dyno.write.consistency";
 
-	// warm up
-	private static final String CONFIG_DYNO_WARM_FORCE = DYNOMITEMANAGER_PRE + ".dyno.warm.force";
-	private static final String CONFIG_DYNO_WARM_BOOTSTRAP = DYNOMITEMANAGER_PRE + ".dyno.warm.bootstrap";
-	private static final String CONFIG_DYNO_ALLOWABLE_BYTES_SYNC_DIFF =
-			DYNOMITEMANAGER_PRE + ".dyno.warm.bytes.sync.diff";
-	private static final String CONFIG_DYNO_MAX_TIME_BOOTSTRAP =
-			DYNOMITEMANAGER_PRE + ".dyno.warm.msec.bootstraptime";
+    // warm up
+    private static final String CONFIG_DYNO_WARM_FORCE = DYNOMITEMANAGER_PRE + ".dyno.warm.force";
+    private static final String CONFIG_DYNO_WARM_BOOTSTRAP = DYNOMITEMANAGER_PRE + ".dyno.warm.bootstrap";
+    private static final String CONFIG_DYNO_ALLOWABLE_BYTES_SYNC_DIFF = DYNOMITEMANAGER_PRE
+	    + ".dyno.warm.bytes.sync.diff";
+    private static final String CONFIG_DYNO_MAX_TIME_BOOTSTRAP = DYNOMITEMANAGER_PRE + ".dyno.warm.msec.bootstraptime";
 
-	// Backup and Restore
-	private static final String CONFIG_BACKUP_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.backup.snapshot.enabled";
-	private static final String CONFIG_BUCKET_NAME = DYNOMITEMANAGER_PRE + ".dyno.backup.bucket.name";
-	private static final String CONFIG_S3_BASE_DIR = DYNOMITEMANAGER_PRE + ".dyno.backup.s3.base_dir";
-	private static final String CONFIG_BACKUP_HOUR = DYNOMITEMANAGER_PRE + ".dyno.backup.hour";
-	private static final String CONFIG_BACKUP_SCHEDULE = DYNOMITEMANAGER_PRE + ".dyno.backup.schedule";
-	private static final String CONFIG_RESTORE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.enabled";
-	private static final String CONFIG_RESTORE_TIME = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.date";
+    // Backup and Restore
+    private static final String CONFIG_BACKUP_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.backup.snapshot.enabled";
+    private static final String CONFIG_BUCKET_NAME = DYNOMITEMANAGER_PRE + ".dyno.backup.bucket.name";
+    private static final String CONFIG_S3_BASE_DIR = DYNOMITEMANAGER_PRE + ".dyno.backup.s3.base_dir";
+    private static final String CONFIG_BACKUP_HOUR = DYNOMITEMANAGER_PRE + ".dyno.backup.hour";
+    private static final String CONFIG_BACKUP_SCHEDULE = DYNOMITEMANAGER_PRE + ".dyno.backup.schedule";
+    private static final String CONFIG_RESTORE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.enabled";
+    private static final String CONFIG_RESTORE_TIME = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.date";
 
-	// persistence
-	private static final String CONFIG_PERSISTENCE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.persistence.enabled";
-	private static final String CONFIG_PERSISTENCE_TYPE = DYNOMITEMANAGER_PRE + ".dyno.persistence.type";
-	private static final String CONFIG_PERSISTENCE_DIR = DYNOMITEMANAGER_PRE + ".dyno.persistence.directory";
+    // persistence
+    private static final String CONFIG_PERSISTENCE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.persistence.enabled";
+    private static final String CONFIG_PERSISTENCE_TYPE = DYNOMITEMANAGER_PRE + ".dyno.persistence.type";
+    private static final String CONFIG_PERSISTENCE_DIR = DYNOMITEMANAGER_PRE + ".dyno.persistence.directory";
 
-	// VPC
-	private static final String CONFIG_INSTANCE_DATA_RETRIEVER = DYNOMITEMANAGER_PRE + ".instanceDataRetriever";
+    // VPC
+    private static final String CONFIG_INSTANCE_DATA_RETRIEVER = DYNOMITEMANAGER_PRE + ".instanceDataRetriever";
 
-	// Defaults
-	private final String DEFAULT_CLUSTER_NAME = "dynomite_demo1";
-	private final String DEFAULT_SEED_PROVIDER = "dynomitemanager_provider";
-	private final String DEFAULT_DYN_HOME_DIR = "/apps/dynomite";
-	private final String DEFAULT_DYN_START_SCRIPT = "/apps/dynomite/bin/launch_dynomite.sh";
-	private final String DEFAULT_DYN_STOP_SCRIPT = "/apps/dynomite/bin/kill_dynomite.sh";
+    // Defaults
+    private final String DEFAULT_CLUSTER_NAME = "dynomite_demo1";
+    private final String DEFAULT_SEED_PROVIDER = "dynomitemanager_provider";
+    private final String DEFAULT_DYN_HOME_DIR = "/apps/dynomite";
+    private final String DEFAULT_DYN_START_SCRIPT = "/apps/dynomite/bin/launch_dynomite.sh";
+    private final String DEFAULT_DYN_STOP_SCRIPT = "/apps/dynomite/bin/kill_dynomite.sh";
 
-	private final String DEFAULT_MEMCACHED_START_SCRIPT = "/apps/memcached/bin/memcached";
-	private final String DEFAULT_MEMCACHED_STOP_SCRIPT = "/usr/bin/pkill memcached";
+    private final String DEFAULT_MEMCACHED_START_SCRIPT = "/apps/memcached/bin/memcached";
+    private final String DEFAULT_MEMCACHED_STOP_SCRIPT = "/usr/bin/pkill memcached";
 
-	private final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
-	private final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
+    private final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
+    private final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
 
-	private List<String> DEFAULT_AVAILABILITY_ZONES = ImmutableList.of();
-	private List<String> DEFAULT_AVAILABILITY_RACKS = ImmutableList.of();
+    private List<String> DEFAULT_AVAILABILITY_ZONES = ImmutableList.of();
+    private List<String> DEFAULT_AVAILABILITY_RACKS = ImmutableList.of();
 
-	private final String DEFAULT_DYN_PROCESS_NAME = "dynomite";
-	private final int DEFAULT_DYN_LISTENER_PORT = 8102;
-	private final int DEFAULT_DYN_SECURED_PEER_PORT = 8101;
-	private final int DEFAULT_DYN_PEER_PORT = 8101;
-	private final int DEFAULT_DYN_MEMCACHED_PORT = 11211;
-	private final String DEFAULT_DYN_RACK = "RAC1";
-	private final String DEFAULT_TOKENS_DISTRIBUTION = "vnode";
-	private final int DEFAULT_DYNO_REQ_TIMEOUT_IN_MILLISEC = 5000;
-	private final int DEFAULT_DYNO_GOSSIP_INTERVAL = 10000;
-	private final String DEFAULT_DYNO_TOKENS_HASH = "murmur";
-	private final int DEFAULT_DYNO_CLUSTER_TYPE = JedisConfiguration.DYNO_REDIS; //redis
+    private final String DEFAULT_DYN_PROCESS_NAME = "dynomite";
+    private final int DEFAULT_DYN_LISTENER_PORT = 8102;
+    private final int DEFAULT_DYN_SECURED_PEER_PORT = 8101;
+    private final int DEFAULT_DYN_PEER_PORT = 8101;
+    private final int DEFAULT_DYN_MEMCACHED_PORT = 11211;
+    private final String DEFAULT_DYN_RACK = "RAC1";
+    private final String DEFAULT_TOKENS_DISTRIBUTION = "vnode";
+    private final int DEFAULT_DYNO_REQ_TIMEOUT_IN_MILLISEC = 5000;
+    private final int DEFAULT_DYNO_GOSSIP_INTERVAL = 10000;
+    private final String DEFAULT_DYNO_TOKENS_HASH = "murmur";
+    private final int DEFAULT_DYNO_CLUSTER_TYPE = JedisConfiguration.DYNO_REDIS; // redis
 
-	private final String DEFAULT_METADATA_KEYSPACE = "dyno_bootstrap";
-	private final String DEFAULT_SECURED_OPTION = "datacenter";
+    private final String DEFAULT_METADATA_KEYSPACE = "dyno_bootstrap";
+    private final String DEFAULT_SECURED_OPTION = "datacenter";
 
-	// Backup & Restore
-	private static final boolean DEFAULT_BACKUP_ENABLED = false;
-	private static final boolean DEFAULT_RESTORE_ENABLED = false;
-	//private static final String DEFAULT_BUCKET_NAME = "us-east-1.dynomite-backup-test";
-	private static final String DEFAULT_BUCKET_NAME = "dynomite-backup";
+    // Backup & Restore
+    private static final boolean DEFAULT_BACKUP_ENABLED = false;
+    private static final boolean DEFAULT_RESTORE_ENABLED = false;
+    // private static final String DEFAULT_BUCKET_NAME =
+    // "us-east-1.dynomite-backup-test";
+    private static final String DEFAULT_BUCKET_NAME = "dynomite-backup";
 
-	private static final String DEFAULT_BUCKET_FOLDER = "backup";
-	private static final String DEFAULT_RESTORE_REPOSITORY_TYPE = "s3";
+    private static final String DEFAULT_BUCKET_FOLDER = "backup";
+    private static final String DEFAULT_RESTORE_REPOSITORY_TYPE = "s3";
 
-	private static final String DEFAULT_RESTORE_SNAPSHOT_NAME = "";
-	private static final String DEFAULT_RESTORE_SOURCE_REPO_REGION = "us-east-1";
-	private static final String DEFAULT_RESTORE_SOURCE_CLUSTER_NAME = "";
-	private static final String DEFAULT_RESTORE_REPOSITORY_NAME = "testrepo";
-	private static final String DEFAULT_RESTORE_TIME = "20101010";
-	private static final String DEFAULT_BACKUP_SCHEDULE = "day";
-	private static final int DEFAULT_BACKUP_HOUR = 12;
+    private static final String DEFAULT_RESTORE_SNAPSHOT_NAME = "";
+    private static final String DEFAULT_RESTORE_SOURCE_REPO_REGION = "us-east-1";
+    private static final String DEFAULT_RESTORE_SOURCE_CLUSTER_NAME = "";
+    private static final String DEFAULT_RESTORE_REPOSITORY_NAME = "testrepo";
+    private static final String DEFAULT_RESTORE_TIME = "20101010";
+    private static final String DEFAULT_BACKUP_SCHEDULE = "day";
+    private static final int DEFAULT_BACKUP_HOUR = 12;
 
-	// Persistence
-	private static final boolean DEFAULT_PERSISTENCE_ENABLED = false;
-	private static final String DEFAULT_PERSISTENCE_TYPE = "aof";
-	private static final String DEFAULT_PERSISTENCE_DIR = "/mnt/data/nfredis";
+    // Persistence
+    private static final boolean DEFAULT_PERSISTENCE_ENABLED = false;
+    private static final String DEFAULT_PERSISTENCE_TYPE = "aof";
+    private static final String DEFAULT_PERSISTENCE_DIR = "/mnt/data/nfredis";
 
-	// AWS Dual Account
-	private static final boolean DEFAULT_DUAL_ACCOUNT = false;
+    // AWS Dual Account
+    private static final boolean DEFAULT_DUAL_ACCOUNT = false;
 
-	private static final Logger logger = LoggerFactory.getLogger(DynomitemanagerConfiguration.class);
+    private static final Logger logger = LoggerFactory.getLogger(DynomitemanagerConfiguration.class);
 
-	private final String CLUSTER_NAME = System.getenv("NETFLIX_APP");
-	private final String AUTO_SCALE_GROUP_NAME = System.getenv("AUTO_SCALE_GROUP");
-	private static final String DEFAULT_INSTANCE_DATA_RETRIEVER = "com.netflix.dynomitemanager.sidecore.config.AwsInstanceDataRetriever";
-	private static final String VPC_INSTANCE_DATA_RETRIEVER = "com.netflix.dynomitemanager.sidecore.config.VpcInstanceDataRetriever";
+    private final String CLUSTER_NAME = System.getenv("NETFLIX_APP");
+    private final String AUTO_SCALE_GROUP_NAME = System.getenv("AUTO_SCALE_GROUP");
+    private static final String DEFAULT_INSTANCE_DATA_RETRIEVER = "com.netflix.dynomitemanager.sidecore.config.AwsInstanceDataRetriever";
+    private static final String VPC_INSTANCE_DATA_RETRIEVER = "com.netflix.dynomitemanager.sidecore.config.VpcInstanceDataRetriever";
 
-	private static String ASG_NAME = System.getenv("ASG_NAME");
-	private static String REGION = System.getenv("EC2_REGION");
+    private static String ASG_NAME = System.getenv("ASG_NAME");
+    private static String REGION = System.getenv("EC2_REGION");
 
-	private final InstanceDataRetriever retriever;
-	private final ICredential provider;
-	private final IConfigSource configSource;
-	private final InstanceEnvIdentity insEnvIdentity;
+    private final InstanceDataRetriever retriever;
+    private final ICredential provider;
+    private final IConfigSource configSource;
+    private final InstanceEnvIdentity insEnvIdentity;
 
-	// Cassandra default configuration
-	private static final String DEFAULT_BOOTCLUSTER_NAME = "cass_dyno";
-	private static final int DEFAULT_CASSANDRA_THRIFT_PORT = 9160; //7102;
-	private static final String DEFAULT_CASSANDRA_KEYSPACE_NAME = "dyno_bootstrap";
-	private static final String DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = "127.0.0.1";
-	private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
+    // Cassandra default configuration
+    private static final String DEFAULT_BOOTCLUSTER_NAME = "cass_dyno";
+    private static final int DEFAULT_CASSANDRA_THRIFT_PORT = 9160; // 7102;
+    private static final String DEFAULT_CASSANDRA_KEYSPACE_NAME = "dyno_bootstrap";
+    private static final String DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES = "127.0.0.1";
+    private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
 
-	//= instance identity meta data
-	private String RAC, ZONE, PUBLIC_HOSTNAME, PUBLIC_IP, INSTANCE_ID, INSTANCE_TYPE;
-	private String NETWORK_MAC;  //Fetch metadata of the running instance's network interface
+    // = instance identity meta data
+    private String RAC, ZONE, PUBLIC_HOSTNAME, PUBLIC_IP, INSTANCE_ID, INSTANCE_TYPE;
+    private String NETWORK_MAC; // Fetch metadata of the running instance's
+				// network interface
 
-	//== vpc specific
-	private String NETWORK_VPC;  //Fetch the vpc id of running instance
+    // == vpc specific
+    private String NETWORK_VPC; // Fetch the vpc id of running instance
 
-	@Inject
-	public DynomitemanagerConfiguration(ICredential provider, IConfigSource configSource,
-			InstanceDataRetriever retriever, InstanceEnvIdentity insEnvIdentity) {
-		this.retriever = retriever;
-		this.provider = provider;
-		this.configSource = configSource;
-		this.insEnvIdentity = insEnvIdentity;
+    @Inject
+    public DynomitemanagerConfiguration(ICredential provider, IConfigSource configSource,
+	    InstanceDataRetriever retriever, InstanceEnvIdentity insEnvIdentity) {
+	this.retriever = retriever;
+	this.provider = provider;
+	this.configSource = configSource;
+	this.insEnvIdentity = insEnvIdentity;
 
-		RAC = retriever.getRac();
-		ZONE = RAC;
-		PUBLIC_HOSTNAME = retriever.getPublicHostname();
-		PUBLIC_IP = retriever.getPublicIP();
+	RAC = retriever.getRac();
+	ZONE = RAC;
+	PUBLIC_HOSTNAME = retriever.getPublicHostname();
+	PUBLIC_IP = retriever.getPublicIP();
 
-		INSTANCE_ID = retriever.getInstanceId();
-		INSTANCE_TYPE = retriever.getInstanceType();
+	INSTANCE_ID = retriever.getInstanceId();
+	INSTANCE_TYPE = retriever.getInstanceType();
 
-		NETWORK_MAC = retriever.getMac();
-		if (insEnvIdentity.isNonDefaultVpc() || insEnvIdentity.isDefaultVpc()) {
-			NETWORK_VPC = retriever.getVpcId();
-			logger.info("vpc id for running instance: " + NETWORK_VPC);
+	NETWORK_MAC = retriever.getMac();
+	if (insEnvIdentity.isNonDefaultVpc() || insEnvIdentity.isDefaultVpc()) {
+	    NETWORK_VPC = retriever.getVpcId();
+	    logger.info("vpc id for running instance: " + NETWORK_VPC);
+	}
+    }
+
+    private InstanceDataRetriever getInstanceDataRetriever()
+	    throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+	String s = null;
+
+	if (this.insEnvIdentity.isClassic()) {
+	    s = this.configSource.get(CONFIG_INSTANCE_DATA_RETRIEVER, DEFAULT_INSTANCE_DATA_RETRIEVER);
+
+	} else if (this.insEnvIdentity.isNonDefaultVpc()) {
+	    s = this.configSource.get(CONFIG_INSTANCE_DATA_RETRIEVER, VPC_INSTANCE_DATA_RETRIEVER);
+	} else {
+	    logger.error("environment cannot be found");
+	    throw new IllegalStateException("Unable to determine environemt (vpc, classic) for running instance.");
+	}
+	return (InstanceDataRetriever) Class.forName(s).newInstance();
+
+    }
+
+    /**
+     * Set Dynomite Manager's configuration options.
+     */
+    public void initialize() {
+	setupEnvVars();
+	this.configSource.initialize(ASG_NAME, REGION);
+	setDefaultRACList(REGION);
+    }
+
+    /**
+     * Set configuration options provided by environment variables or Java
+     * properties. Java properties are only used if the equivalent environment
+     * variable is not set.
+     *
+     * Environment variables and Java properties are applied in the following
+     * order:
+     * <ol>
+     * <li>Environment variable: Preferred value
+     * <li>Java property: If environment variable is not set, then Java property
+     * is used.
+     * </ol>
+     */
+    private void setupEnvVars() {
+	// Search in java opt properties
+	try {
+	    logger.info("Setting up environmental variables and Java properties.");
+	    REGION = StringUtils.isBlank(REGION) ? System.getProperty("EC2_REGION") : REGION;
+	    // Infer from zone
+	    if (StringUtils.isBlank(REGION))
+		REGION = this.retriever.getRac().substring(0, this.retriever.getRac().length() - 1);
+	    ASG_NAME = StringUtils.isBlank(ASG_NAME) ? System.getProperty("ASG_NAME") : ASG_NAME;
+	    if (StringUtils.isBlank(ASG_NAME))
+		ASG_NAME = populateASGName(REGION, this.retriever.getInstanceId());
+	    logger.info(String.format("REGION set to %s, ASG Name set to %s", REGION, ASG_NAME));
+	} catch (Exception e) {
+	    throw new RuntimeException(e.getMessage(), e);
+	}
+    }
+
+    /**
+     * Query Amazon to get ASG name. Currently not available as part of instance
+     * info api.
+     */
+    private String populateASGName(String region, String instanceId) {
+	GetASGName getASGName = new GetASGName(region, instanceId);
+
+	try {
+	    return getASGName.call();
+	} catch (Exception e) {
+	    logger.error("Failed to determine ASG name.", e);
+	    return null;
+	}
+    }
+
+    private class GetASGName extends RetryableCallable<String> {
+	private static final int NUMBER_OF_RETRIES = 15;
+	private static final long WAIT_TIME = 30000;
+	private final String instanceId;
+	private final AmazonEC2 client;
+
+	public GetASGName(String region, String instanceId) {
+	    super(NUMBER_OF_RETRIES, WAIT_TIME);
+	    this.instanceId = instanceId;
+	    client = new AmazonEC2Client(provider.getAwsCredentialProvider());
+	    client.setEndpoint("ec2." + region + ".amazonaws.com");
+	}
+
+	@Override
+	public String retriableCall() throws IllegalStateException {
+	    DescribeInstancesRequest desc = new DescribeInstancesRequest().withInstanceIds(instanceId);
+	    DescribeInstancesResult res = client.describeInstances(desc);
+
+	    for (Reservation resr : res.getReservations()) {
+		for (Instance ins : resr.getInstances()) {
+		    for (com.amazonaws.services.ec2.model.Tag tag : ins.getTags()) {
+			if (tag.getKey().equals("aws:autoscaling:groupName"))
+			    return tag.getValue();
+		    }
 		}
-	}
-
-	private InstanceDataRetriever getInstanceDataRetriever()
-			throws InstantiationException, IllegalAccessException, ClassNotFoundException {
-		String s = null;
-
-		if (this.insEnvIdentity.isClassic()) {
-			s = this.configSource.get(CONFIG_INSTANCE_DATA_RETRIEVER, DEFAULT_INSTANCE_DATA_RETRIEVER);
-
-		} else if (this.insEnvIdentity.isNonDefaultVpc()) {
-			s = this.configSource.get(CONFIG_INSTANCE_DATA_RETRIEVER, VPC_INSTANCE_DATA_RETRIEVER);
-		} else {
-			logger.error("environment cannot be found");
-			throw new IllegalStateException(
-					"Unable to determine environemt (vpc, classic) for running instance.");
-		}
-		return (InstanceDataRetriever) Class.forName(s).newInstance();
-
-	}
-
-	/**
-	 * Set Dynomite Manager's configuration options.
-	 */
-	public void initialize() {
-		setupEnvVars();
-		this.configSource.initialize(ASG_NAME, REGION);
-		setDefaultRACList(REGION);
-	}
-
-	/**
-	 * Set configuration options provided by environment variables or Java properties. Java properties are only used
-	 * if the equivalent environment variable is not set.
-	 *
-	 * Environment variables and Java properties are applied in the following order:
-	 * <ol>
-	 * <li>Environment variable: Preferred value
-	 * <li>Java property: If environment variable is not set, then Java property is used.
-	 * </ol>
-	 */
-	private void setupEnvVars() {
-		// Search in java opt properties
-		try {
-			logger.info("Setting up environmental variables and Java properties.");
-			REGION = StringUtils.isBlank(REGION) ? System.getProperty("EC2_REGION") : REGION;
-			// Infer from zone
-			if (StringUtils.isBlank(REGION))
-				REGION = this.retriever.getRac().substring(0, this.retriever.getRac().length() - 1);
-			ASG_NAME = StringUtils.isBlank(ASG_NAME) ? System.getProperty("ASG_NAME") : ASG_NAME;
-			if (StringUtils.isBlank(ASG_NAME))
-				ASG_NAME = populateASGName(REGION, this.retriever.getInstanceId());
-			logger.info(String.format("REGION set to %s, ASG Name set to %s", REGION, ASG_NAME));
-		} catch (Exception e) {
-			throw new RuntimeException(e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * Query Amazon to get ASG name. Currently not available as part of instance info api.
-	 */
-	private String populateASGName(String region, String instanceId) {
-		GetASGName getASGName = new GetASGName(region, instanceId);
-
-		try {
-			return getASGName.call();
-		} catch (Exception e) {
-			logger.error("Failed to determine ASG name.", e);
-			return null;
-		}
-	}
-
-	private class GetASGName extends RetryableCallable<String> {
-		private static final int NUMBER_OF_RETRIES = 15;
-		private static final long WAIT_TIME = 30000;
-		private final String instanceId;
-		private final AmazonEC2 client;
-
-		public GetASGName(String region, String instanceId) {
-			super(NUMBER_OF_RETRIES, WAIT_TIME);
-			this.instanceId = instanceId;
-			client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-			client.setEndpoint("ec2." + region + ".amazonaws.com");
-		}
-
-		@Override
-		public String retriableCall() throws IllegalStateException {
-			DescribeInstancesRequest desc = new DescribeInstancesRequest().withInstanceIds(instanceId);
-			DescribeInstancesResult res = client.describeInstances(desc);
-
-			for (Reservation resr : res.getReservations()) {
-				for (Instance ins : resr.getInstances()) {
-					for (com.amazonaws.services.ec2.model.Tag tag : ins.getTags()) {
-						if (tag.getKey().equals("aws:autoscaling:groupName"))
-							return tag.getValue();
-					}
-				}
-			}
-
-			logger.warn("Couldn't determine ASG name");
-			throw new IllegalStateException("Couldn't determine ASG name");
-		}
-	}
-
-	private boolean useAsgForRackName() {
-		return configSource.get(CONFIG_USE_ASG_FOR_RACK_NAME, true);
-	}
-
-	@Override
-	public String getAppStartupScript() {
-		return configSource.get(CONFIG_DYN_START_SCRIPT, DEFAULT_DYN_START_SCRIPT);
-	}
-
-	@Override
-	public String getAppStopScript() {
-		return configSource.get(CONFIG_DYN_STOP_SCRIPT, DEFAULT_DYN_STOP_SCRIPT);
-	}
-
-	@Override
-	public String getAppName() {
-		String clusterName = System.getenv("NETFLIX_APP");
-
-		if (StringUtils.isBlank(clusterName))
-			return configSource.get(CONFIG_CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
-
-		return clusterName;
-	}
-
-	@Override
-	public String getAppHome() {
-		return configSource.get(CONFIG_DYN_HOME_DIR, DEFAULT_DYN_HOME_DIR);
-	}
-
-	@Override
-	public String getZone() {
-		return ZONE;
-	}
-
-	@Override
-	public String getHostname() {
-		return PUBLIC_HOSTNAME;
-	}
-
-	@Override
-	public String getInstanceName() {
-		return INSTANCE_ID;
-	}
-
-	@Override
-	public String getRack() {
-		if (useAsgForRackName()) {
-			return getASGName();
-		}
-
-		return configSource.get(CONFIG_RACK_NAME, DEFAULT_DYN_RACK);
-	}
-
-	@Override
-	public List<String> getZones() {
-		return configSource.getList(CONFIG_AVAILABILITY_ZONES, DEFAULT_AVAILABILITY_ZONES);
-	}
-
-	public List<String> getRacks() {
-		return configSource.getList(CONFIG_AVAILABILITY_RACKS, DEFAULT_AVAILABILITY_RACKS);
-	}
-
-	public String getRegion() {
-		return System.getenv("EC2_REGION") == null ?
-				configSource.get(CONFIG_REGION_NAME, "") :
-				System.getenv("EC2_REGION");
-	}
-
-	@Override
-	public String getASGName() {
-		return AUTO_SCALE_GROUP_NAME;
-	}
-
-	/**
-	 * Get the fist 3 available zones in the region
-	 */
-	public void setDefaultRACList(String region) {
-		AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-		client.setEndpoint("ec2." + region + ".amazonaws.com");
-		DescribeAvailabilityZonesResult res = client.describeAvailabilityZones();
-		List<String> zone = Lists.newArrayList();
-		for (AvailabilityZone reg : res.getAvailabilityZones()) {
-			if (reg.getState().equals("available"))
-				zone.add(reg.getZoneName());
-			if (zone.size() == 3)
-				break;
-		}
-		//        DEFAULT_AVAILABILITY_ZONES =  StringUtils.join(zone, ",");
-		DEFAULT_AVAILABILITY_ZONES = ImmutableList.copyOf(zone);
-	}
-
-	@Override
-	public String getACLGroupName() {
-		return configSource.get(CONFIG_ACL_GROUP_NAME, this.getAppName());
-	}
-
-	@Override
-	public String getHostIP() {
-		return PUBLIC_IP;
-	}
-
-	@Override
-	public String getBootClusterName() {
-		return configSource.get(CONFIG_BOOTCLUSTER_NAME, DEFAULT_BOOTCLUSTER_NAME);
-	}
-
-	@Override
-	public String getSeedProviderName() {
-		return configSource.get(CONFIG_SEED_PROVIDER_NAME, DEFAULT_SEED_PROVIDER);
-	}
-
-	@Override
-	public String getProcessName() {
-		return configSource.get(CONFIG_DYN_PROCESS_NAME, DEFAULT_DYN_PROCESS_NAME);
-	}
-
-	public String getYamlLocation() {
-		return configSource.get(CONFIG_YAML_LOCATION, getAppHome() + "/conf/dynomite.yml");
-	}
-
-	@Override
-	public boolean getAutoEjectHosts() {
-		return configSource.get(CONFIG_DYNO_AUTO_EJECT_HOSTS, true);
-	}
-
-	@Override
-	public String getDistribution() {
-		return configSource.get(CONFIG_TOKENS_DISTRIBUTION_NAME, DEFAULT_TOKENS_DISTRIBUTION);
-	}
-
-	@Override
-	public int getListenerPort() {
-		return configSource.get(CONFIG_DYN_LISTENER_PORT_NAME, DEFAULT_DYN_LISTENER_PORT);
-	}
-
-	@Override
-	public String getClientListenPort() {
-		return "0.0.0.0:" + getListenerPort();
-	}
-
-	@Override
-	public int getPeerListenerPort() {
-		return configSource.get(CONFIG_DYN_PEER_PORT_NAME, DEFAULT_DYN_PEER_PORT);
-	}
-
-	@Override
-	public String getDynListenPort() { //return full string
-		return "0.0.0.0:" + getPeerListenerPort();
-	}
-
-	@Override
-	public int getGossipInterval() {
-		return configSource.get(CONFIG_DYNO_GOSSIP_INTERVAL_NAME, DEFAULT_DYNO_GOSSIP_INTERVAL);
-	}
-
-	@Override
-	public String getHash() {
-		return configSource.get(CONFIG_DYNO_TOKENS_HASH_NAME, DEFAULT_DYNO_TOKENS_HASH);
-	}
-
-	@Override
-	public boolean getPreconnect() {
-		return configSource.get(CONFIG_DYNO_CONNECTIONS_PRECONNECT, true);
-	}
-
-	@Override
-	public int getServerRetryTimeout() {
-		return 30000;
-	}
-
-	@Override
-	public int getTimeout() {
-		return configSource.get(CONFIG_DYNO_REQ_TIMEOUT_NAME, DEFAULT_DYNO_REQ_TIMEOUT_IN_MILLISEC);
-	}
-
-	public String getMetadataKeyspace() {
-		return configSource.get(CONFIG_METADATA_KEYSPACE, DEFAULT_METADATA_KEYSPACE);
-	}
-
-	@Override
-	public String getTokens() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	/* 0 - memcached
-	 * 1 - redis
-	 */
-	public int getClusterType() {
-		return configSource.get(CONFIG_DYNO_CLUSTER_TYPE, DEFAULT_DYNO_CLUSTER_TYPE);
-	}
-
-	public boolean isMultiRegionedCluster() {
-		return configSource.get(CONFIG_DYNO_IS_MULTI_REGIONED_CLUSTER, true);
-	}
-
-	@Override
-	public int getSecuredPeerListenerPort() {
-		return configSource.get(CONFIG_DYN_SECURED_PEER_PORT_NAME, DEFAULT_DYN_SECURED_PEER_PORT);
-	}
-
-	public String getSecuredOption() {
-		return configSource.get(CONFIG_SECURED_OPTION, DEFAULT_SECURED_OPTION);
-	}
-
-	public boolean isHealthCheckEnable() {
-		return configSource.get(CONFIG_DYNO_HEALTHCHECK_ENABLE, true);
-	}
-
-	public boolean isWarmBootstrap() {
-		return configSource.get(CONFIG_DYNO_WARM_BOOTSTRAP, false);
-	}
-
-	public boolean isForceWarm() {
-		return configSource.get(CONFIG_DYNO_WARM_FORCE, false);
-	}
-
-	public int getAllowableBytesSyncDiff() {
-		return configSource.get(CONFIG_DYNO_ALLOWABLE_BYTES_SYNC_DIFF, 100000);
-	}
-
-	public int getMaxTimeToBootstrap() {
-		return configSource.get(CONFIG_DYNO_MAX_TIME_BOOTSTRAP, 900000);
-	}
-
-	public String getReadConsistency() {
-		return configSource.get(CONFIG_DYNO_READ_CONS, "DC_ONE");
-	}
-
-	public String getWriteConsistency() {
-		return configSource.get(CONFIG_DYNO_WRITE_CONS, "DC_ONE");
-	}
-
-	@Override
-	public int getStorageMemPercent() {
-		return configSource.get(CONFIG_DYNO_STORAGE_MEM_PCT_INT, 85);
-	}
-
-	@Override
-	public String getStorageStartupScript() {
-		if (getClusterType() == 0)
-			return DEFAULT_MEMCACHED_START_SCRIPT;
-
-		return DEFAULT_REDIS_START_SCRIPT;
-	}
-
-	@Override
-	public String getStorageStopScript() {
-		if (getClusterType() == 0)
-			return DEFAULT_MEMCACHED_STOP_SCRIPT;
-
-		return DEFAULT_REDIS_STOP_SCRIPT;
-	}
-
-	public int getMbufSize() {
-		return configSource.get(CONFIG_DYNO_MBUF_SIZE, 16384);
-	}
-
-	public int getAllocatedMessages() {
-		return configSource.get(CONFIG_DYNO_MAX_ALLOC_MSGS, 200000);
-	}
-
-	public boolean isVpc() {
-		return configSource.get(CONFIG_VPC, false);
-	}
-
-	// Backup & Restore Implementations
-
-	@Override
-	public String getPersistenceLocation() {
-		return configSource.get(CONFIG_PERSISTENCE_DIR, DEFAULT_PERSISTENCE_DIR);
-	}
-
-	@Override
-	public String getBucketName() {
-		return configSource.get(CONFIG_BUCKET_NAME, DEFAULT_BUCKET_NAME);
-	}
-
-	@Override
-	public String getBackupLocation() {
-		return configSource.get(CONFIG_S3_BASE_DIR, DEFAULT_BUCKET_FOLDER);
-	}
-
-	@Override
-	public boolean isBackupEnabled() {
-		return configSource.get(CONFIG_BACKUP_ENABLED, DEFAULT_BACKUP_ENABLED);
-	}
-
-	@Override
-	public boolean isRestoreEnabled() {
-		return configSource.get(CONFIG_RESTORE_ENABLED, DEFAULT_RESTORE_ENABLED);
-	}
-
-	@Override
-	public String getBackupSchedule() {
-		if (CONFIG_BACKUP_SCHEDULE != null &&
-				!"day".equals(CONFIG_BACKUP_SCHEDULE) &&
-				!"week".equals(CONFIG_BACKUP_SCHEDULE)) {
-
-			logger.error("The persistence schedule FP is wrong: day or week");
-			logger.error("Defaulting to day");
-			return configSource.get("day", DEFAULT_BACKUP_SCHEDULE);
-		}
-		return configSource.get(CONFIG_BACKUP_SCHEDULE, DEFAULT_BACKUP_SCHEDULE);
-	}
-
-	@Override
-	public int getBackupHour() {
-		return configSource.get(CONFIG_BACKUP_HOUR, DEFAULT_BACKUP_HOUR);
-	}
-
-	@Override
-	public String getRestoreDate() {
-		return configSource.get(CONFIG_RESTORE_TIME, DEFAULT_RESTORE_TIME);
-	}
-
-	@Override
-	public boolean isPersistenceEnabled() {
-		return configSource.get(CONFIG_PERSISTENCE_ENABLED, DEFAULT_PERSISTENCE_ENABLED);
-	}
-
-	@Override
-	public boolean isAof() {
-
-		if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("rdb")) {
-			return false;
-		} else if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("aof")) {
-			return true;
-		} else {
-			logger.error("The persistence type FP is wrong: aof or rdb");
-			logger.error("Defaulting to rdb");
-			return false;
-		}
-
-	}
-
-	// VPC
-	public String getVpcId() {
-		return NETWORK_VPC;
-	}
-
-	@Override
-	public String getClassicAWSRoleAssumptionArn() {
-		return configSource.get(CONFIG_EC2_ROLE_ASSUMPTION_ARN);
-	}
-
-	@Override
-	public String getVpcAWSRoleAssumptionArn() {
-		return configSource.get(CONFIG_VPC_ROLE_ASSUMPTION_ARN);
-	}
-
-	@Override
-	public boolean isDualAccount() {
-		return configSource.get(CONFIG_DUAL_ACCOUNT, DEFAULT_DUAL_ACCOUNT);
-	}
-
-	// Cassandra configuration for token management
-	@Override
-	public String getCassandraKeyspaceName() {
-		return configSource.get(CONFIG_CASSANDRA_KEYSPACE_NAME, DEFAULT_CASSANDRA_KEYSPACE_NAME);
-	}
-
-	@Override
-	public int getCassandraThriftPortForAstyanax() {
-		return configSource.get(CONFIG_CASSANDRA_THRIFT_PORT, DEFAULT_CASSANDRA_THRIFT_PORT);
-	}
-
-	@Override
-	public String getCommaSeparatedCassandraHostNames() {
-		return configSource.get(CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES,
-				DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES);
-	}
-
-	@Override
-	public boolean isEurekaHostSupplierEnabled() {
-		return configSource
-				.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
-	}
+	    }
+
+	    logger.warn("Couldn't determine ASG name");
+	    throw new IllegalStateException("Couldn't determine ASG name");
+	}
+    }
+
+    private boolean useAsgForRackName() {
+	return configSource.get(CONFIG_USE_ASG_FOR_RACK_NAME, true);
+    }
+
+    @Override
+    public String getAppStartupScript() {
+	return configSource.get(CONFIG_DYN_START_SCRIPT, DEFAULT_DYN_START_SCRIPT);
+    }
+
+    @Override
+    public String getAppStopScript() {
+	return configSource.get(CONFIG_DYN_STOP_SCRIPT, DEFAULT_DYN_STOP_SCRIPT);
+    }
+
+    @Override
+    public String getAppName() {
+	String clusterName = System.getenv("NETFLIX_APP");
+
+	if (StringUtils.isBlank(clusterName))
+	    return configSource.get(CONFIG_CLUSTER_NAME, DEFAULT_CLUSTER_NAME);
+
+	return clusterName;
+    }
+
+    @Override
+    public String getAppHome() {
+	return configSource.get(CONFIG_DYN_HOME_DIR, DEFAULT_DYN_HOME_DIR);
+    }
+
+    @Override
+    public String getZone() {
+	return ZONE;
+    }
+
+    @Override
+    public String getHostname() {
+	return PUBLIC_HOSTNAME;
+    }
+
+    @Override
+    public String getInstanceName() {
+	return INSTANCE_ID;
+    }
+
+    @Override
+    public String getRack() {
+	if (useAsgForRackName()) {
+	    return getASGName();
+	}
+
+	return configSource.get(CONFIG_RACK_NAME, DEFAULT_DYN_RACK);
+    }
+
+    @Override
+    public List<String> getZones() {
+	return configSource.getList(CONFIG_AVAILABILITY_ZONES, DEFAULT_AVAILABILITY_ZONES);
+    }
+
+    @Override
+    public String getCrossAccountRack() {
+	// If a fast property is not set, it uses the local rack name
+	return configSource.get(CONFIG_DUAL_ACCOUNT_AZ, getRack());
+    }
+
+    public List<String> getRacks() {
+	return configSource.getList(CONFIG_AVAILABILITY_RACKS, DEFAULT_AVAILABILITY_RACKS);
+    }
+
+    public String getRegion() {
+	return System.getenv("EC2_REGION") == null ? configSource.get(CONFIG_REGION_NAME, "")
+		: System.getenv("EC2_REGION");
+    }
+
+    @Override
+    public String getASGName() {
+	return AUTO_SCALE_GROUP_NAME;
+    }
+
+    /**
+     * Get the fist 3 available zones in the region
+     */
+    public void setDefaultRACList(String region) {
+	AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
+	client.setEndpoint("ec2." + region + ".amazonaws.com");
+	DescribeAvailabilityZonesResult res = client.describeAvailabilityZones();
+	List<String> zone = Lists.newArrayList();
+	for (AvailabilityZone reg : res.getAvailabilityZones()) {
+	    if (reg.getState().equals("available"))
+		zone.add(reg.getZoneName());
+	    if (zone.size() == 3)
+		break;
+	}
+	// DEFAULT_AVAILABILITY_ZONES = StringUtils.join(zone, ",");
+	DEFAULT_AVAILABILITY_ZONES = ImmutableList.copyOf(zone);
+    }
+
+    @Override
+    public String getACLGroupName() {
+	return configSource.get(CONFIG_ACL_GROUP_NAME, this.getAppName());
+    }
+
+    @Override
+    public String getHostIP() {
+	return PUBLIC_IP;
+    }
+
+    @Override
+    public String getBootClusterName() {
+	return configSource.get(CONFIG_BOOTCLUSTER_NAME, DEFAULT_BOOTCLUSTER_NAME);
+    }
+
+    @Override
+    public String getSeedProviderName() {
+	return configSource.get(CONFIG_SEED_PROVIDER_NAME, DEFAULT_SEED_PROVIDER);
+    }
+
+    @Override
+    public String getProcessName() {
+	return configSource.get(CONFIG_DYN_PROCESS_NAME, DEFAULT_DYN_PROCESS_NAME);
+    }
+
+    public String getYamlLocation() {
+	return configSource.get(CONFIG_YAML_LOCATION, getAppHome() + "/conf/dynomite.yml");
+    }
+
+    @Override
+    public boolean getAutoEjectHosts() {
+	return configSource.get(CONFIG_DYNO_AUTO_EJECT_HOSTS, true);
+    }
+
+    @Override
+    public String getDistribution() {
+	return configSource.get(CONFIG_TOKENS_DISTRIBUTION_NAME, DEFAULT_TOKENS_DISTRIBUTION);
+    }
+
+    @Override
+    public int getListenerPort() {
+	return configSource.get(CONFIG_DYN_LISTENER_PORT_NAME, DEFAULT_DYN_LISTENER_PORT);
+    }
+
+    @Override
+    public String getClientListenPort() {
+	return "0.0.0.0:" + getListenerPort();
+    }
+
+    @Override
+    public int getPeerListenerPort() {
+	return configSource.get(CONFIG_DYN_PEER_PORT_NAME, DEFAULT_DYN_PEER_PORT);
+    }
+
+    @Override
+    public String getDynListenPort() { // return full string
+	return "0.0.0.0:" + getPeerListenerPort();
+    }
+
+    @Override
+    public int getGossipInterval() {
+	return configSource.get(CONFIG_DYNO_GOSSIP_INTERVAL_NAME, DEFAULT_DYNO_GOSSIP_INTERVAL);
+    }
+
+    @Override
+    public String getHash() {
+	return configSource.get(CONFIG_DYNO_TOKENS_HASH_NAME, DEFAULT_DYNO_TOKENS_HASH);
+    }
+
+    @Override
+    public boolean getPreconnect() {
+	return configSource.get(CONFIG_DYNO_CONNECTIONS_PRECONNECT, true);
+    }
+
+    @Override
+    public int getServerRetryTimeout() {
+	return 30000;
+    }
+
+    @Override
+    public int getTimeout() {
+	return configSource.get(CONFIG_DYNO_REQ_TIMEOUT_NAME, DEFAULT_DYNO_REQ_TIMEOUT_IN_MILLISEC);
+    }
+
+    public String getMetadataKeyspace() {
+	return configSource.get(CONFIG_METADATA_KEYSPACE, DEFAULT_METADATA_KEYSPACE);
+    }
+
+    @Override
+    public String getTokens() {
+	// TODO Auto-generated method stub
+	return null;
+    }
+
+    /*
+     * 0 - memcached 1 - redis
+     */
+    public int getClusterType() {
+	return configSource.get(CONFIG_DYNO_CLUSTER_TYPE, DEFAULT_DYNO_CLUSTER_TYPE);
+    }
+
+    public boolean isMultiRegionedCluster() {
+	return configSource.get(CONFIG_DYNO_IS_MULTI_REGIONED_CLUSTER, true);
+    }
+
+    @Override
+    public int getSecuredPeerListenerPort() {
+	return configSource.get(CONFIG_DYN_SECURED_PEER_PORT_NAME, DEFAULT_DYN_SECURED_PEER_PORT);
+    }
+
+    public String getSecuredOption() {
+	return configSource.get(CONFIG_SECURED_OPTION, DEFAULT_SECURED_OPTION);
+    }
+
+    public boolean isHealthCheckEnable() {
+	return configSource.get(CONFIG_DYNO_HEALTHCHECK_ENABLE, true);
+    }
+
+    public boolean isWarmBootstrap() {
+	return configSource.get(CONFIG_DYNO_WARM_BOOTSTRAP, false);
+    }
+
+    public boolean isForceWarm() {
+	return configSource.get(CONFIG_DYNO_WARM_FORCE, false);
+    }
+
+    public int getAllowableBytesSyncDiff() {
+	return configSource.get(CONFIG_DYNO_ALLOWABLE_BYTES_SYNC_DIFF, 100000);
+    }
+
+    public int getMaxTimeToBootstrap() {
+	return configSource.get(CONFIG_DYNO_MAX_TIME_BOOTSTRAP, 900000);
+    }
+
+    public String getReadConsistency() {
+	return configSource.get(CONFIG_DYNO_READ_CONS, "DC_ONE");
+    }
+
+    public String getWriteConsistency() {
+	return configSource.get(CONFIG_DYNO_WRITE_CONS, "DC_ONE");
+    }
+
+    @Override
+    public int getStorageMemPercent() {
+	return configSource.get(CONFIG_DYNO_STORAGE_MEM_PCT_INT, 85);
+    }
+
+    @Override
+    public String getStorageStartupScript() {
+	if (getClusterType() == 0)
+	    return DEFAULT_MEMCACHED_START_SCRIPT;
+
+	return DEFAULT_REDIS_START_SCRIPT;
+    }
+
+    @Override
+    public String getStorageStopScript() {
+	if (getClusterType() == 0)
+	    return DEFAULT_MEMCACHED_STOP_SCRIPT;
+
+	return DEFAULT_REDIS_STOP_SCRIPT;
+    }
+
+    public int getMbufSize() {
+	return configSource.get(CONFIG_DYNO_MBUF_SIZE, 16384);
+    }
+
+    public int getAllocatedMessages() {
+	return configSource.get(CONFIG_DYNO_MAX_ALLOC_MSGS, 200000);
+    }
+
+    public boolean isVpc() {
+	return configSource.get(CONFIG_VPC, false);
+    }
+
+    // Backup & Restore Implementations
+
+    @Override
+    public String getPersistenceLocation() {
+	return configSource.get(CONFIG_PERSISTENCE_DIR, DEFAULT_PERSISTENCE_DIR);
+    }
+
+    @Override
+    public String getBucketName() {
+	return configSource.get(CONFIG_BUCKET_NAME, DEFAULT_BUCKET_NAME);
+    }
+
+    @Override
+    public String getBackupLocation() {
+	return configSource.get(CONFIG_S3_BASE_DIR, DEFAULT_BUCKET_FOLDER);
+    }
+
+    @Override
+    public boolean isBackupEnabled() {
+	return configSource.get(CONFIG_BACKUP_ENABLED, DEFAULT_BACKUP_ENABLED);
+    }
+
+    @Override
+    public boolean isRestoreEnabled() {
+	return configSource.get(CONFIG_RESTORE_ENABLED, DEFAULT_RESTORE_ENABLED);
+    }
+
+    @Override
+    public String getBackupSchedule() {
+	if (CONFIG_BACKUP_SCHEDULE != null && !"day".equals(CONFIG_BACKUP_SCHEDULE)
+		&& !"week".equals(CONFIG_BACKUP_SCHEDULE)) {
+
+	    logger.error("The persistence schedule FP is wrong: day or week");
+	    logger.error("Defaulting to day");
+	    return configSource.get("day", DEFAULT_BACKUP_SCHEDULE);
+	}
+	return configSource.get(CONFIG_BACKUP_SCHEDULE, DEFAULT_BACKUP_SCHEDULE);
+    }
+
+    @Override
+    public int getBackupHour() {
+	return configSource.get(CONFIG_BACKUP_HOUR, DEFAULT_BACKUP_HOUR);
+    }
+
+    @Override
+    public String getRestoreDate() {
+	return configSource.get(CONFIG_RESTORE_TIME, DEFAULT_RESTORE_TIME);
+    }
+
+    @Override
+    public boolean isPersistenceEnabled() {
+	return configSource.get(CONFIG_PERSISTENCE_ENABLED, DEFAULT_PERSISTENCE_ENABLED);
+    }
+
+    @Override
+    public boolean isAof() {
+
+	if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("rdb")) {
+	    return false;
+	} else if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("aof")) {
+	    return true;
+	} else {
+	    logger.error("The persistence type FP is wrong: aof or rdb");
+	    logger.error("Defaulting to rdb");
+	    return false;
+	}
+
+    }
+
+    // VPC
+    public String getVpcId() {
+	return NETWORK_VPC;
+    }
+
+    @Override
+    public String getClassicAWSRoleAssumptionArn() {
+	return configSource.get(CONFIG_EC2_ROLE_ASSUMPTION_ARN);
+    }
+
+    @Override
+    public String getVpcAWSRoleAssumptionArn() {
+	return configSource.get(CONFIG_VPC_ROLE_ASSUMPTION_ARN);
+    }
+
+    @Override
+    public boolean isDualAccount() {
+	return configSource.get(CONFIG_DUAL_ACCOUNT, DEFAULT_DUAL_ACCOUNT);
+    }
+
+    // Cassandra configuration for token management
+    @Override
+    public String getCassandraKeyspaceName() {
+	return configSource.get(CONFIG_CASSANDRA_KEYSPACE_NAME, DEFAULT_CASSANDRA_KEYSPACE_NAME);
+    }
+
+    @Override
+    public int getCassandraThriftPortForAstyanax() {
+	return configSource.get(CONFIG_CASSANDRA_THRIFT_PORT, DEFAULT_CASSANDRA_THRIFT_PORT);
+    }
+
+    @Override
+    public String getCommaSeparatedCassandraHostNames() {
+	return configSource.get(CONFIG_COMMA_SEPARATED_CASSANDRA_HOSTNAMES,
+		DEFAULT_COMMA_SEPARATED_CASSANDRA_HOSTNAMES);
+    }
+
+    @Override
+    public boolean isEurekaHostSupplierEnabled() {
+	return configSource.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
+    }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Initialize Dynomite Manager and bind dependencies, setup Dynomite Manager configuration, write dynomite.yaml and
  * redis.conf, start/stop Dynomite, start/stop the storage engine (Redis or Memcached), and configure the Jedis client
  * for Redis.

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteRest.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteRest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dynomitemanager.dynomite;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/IMembership.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/IMembership.java
@@ -41,6 +41,12 @@ public interface IMembership {
 	public int getRacMembershipSize();
 
 	/**
+	 * @return Size of the cross account RAC
+	 */
+	public int getCrossAccountRacMembershipSize();
+
+	
+	/**
 	 * Number of RACs
 	 */
 	public int getRacCount();
@@ -74,5 +80,6 @@ public interface IMembership {
 	 * @param count
 	 */
 	public void expandRacMembership(int count);
+
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceEnvIdentity.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceEnvIdentity.java
@@ -16,24 +16,26 @@ package com.netflix.dynomitemanager.identity;
  * A means to determine the environment for the running instance
  */
 public interface InstanceEnvIdentity {
-	/*
-	 * @return true if running instance is in "classic", false otherwise.
-	 */
-	public Boolean isClassic();
+    /*
+     * @return true if running instance is in "classic", false otherwise.
+     */
+    public Boolean isClassic();
 
-	/*
-	 * @return true if running instance is in VPC, under your default AWS account, false otherwise.
-	 */
-	public Boolean isDefaultVpc();
+    /*
+     * @return true if running instance is in VPC, under your default AWS
+     * account, false otherwise.
+     */
+    public Boolean isDefaultVpc();
 
-	/*
-	 * @return true if running instance is in VPC, under a specific AWS account, false otherwise.
-	 */
-	public Boolean isNonDefaultVpc();
+    /*
+     * @return true if running instance is in VPC, under a specific AWS account,
+     * false otherwise.
+     */
+    public Boolean isNonDefaultVpc();
 
-	public static enum InstanceEnvironent {
-		CLASSIC, DEFAULT_VPC, NONDEFAULT_VPC
-	}
+    public static enum InstanceEnvironent {
+	CLASSIC, DEFAULT_VPC, NONDEFAULT_VPC
+    }
 
-	;
+  
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceIdentity.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceIdentity.java
@@ -48,335 +48,318 @@ import com.netflix.dynomitemanager.identity.InstanceIdentity;
 
 @Singleton
 public class InstanceIdentity {
-	private static final Logger logger = LoggerFactory.getLogger(InstanceIdentity.class);
-	private static final String DUMMY_INSTANCE_ID = "new_slot";
+    private static final Logger logger = LoggerFactory.getLogger(InstanceIdentity.class);
+    private static final String DUMMY_INSTANCE_ID = "new_slot";
 
-	private final ListMultimap<String, AppsInstance> locMap = Multimaps
-			.newListMultimap(new HashMap<String, Collection<AppsInstance>>(),
-					new Supplier<List<AppsInstance>>() {
-						public List<AppsInstance> get() {
-							return Lists.newArrayList();
-						}
-					});
-	private final IAppsInstanceFactory factory;
-	private final IMembership membership;
-	private final IConfiguration config;
-	private final Sleeper sleeper;
-	private final ITokenManager tokenManager;
-	private final InstanceEnvIdentity insEnvIdentity;
-
-	private final Predicate<AppsInstance> differentHostPredicate = new Predicate<AppsInstance>() {
-		@Override
-		public boolean apply(AppsInstance instance) {
-			return (!instance.getInstanceId().equalsIgnoreCase(DUMMY_INSTANCE_ID) && !instance.getHostName()
-					.equals(myInstance.getHostName()));
+    private final ListMultimap<String, AppsInstance> locMap = Multimaps
+	    .newListMultimap(new HashMap<String, Collection<AppsInstance>>(), new Supplier<List<AppsInstance>>() {
+		public List<AppsInstance> get() {
+		    return Lists.newArrayList();
 		}
-	};
+	    });
+    private final IAppsInstanceFactory factory;
+    private final IMembership membership;
+    private final IConfiguration config;
+    private final Sleeper sleeper;
+    private final ITokenManager tokenManager;
+    private final InstanceEnvIdentity insEnvIdentity;
 
-	private AppsInstance myInstance;
-	private boolean isReplace = false;
-	private boolean isTokenPregenerated = false;
-	private String replacedIp = "";
-
-	@Inject
-	public InstanceIdentity(IAppsInstanceFactory factory, IMembership membership, IConfiguration config,
-			Sleeper sleeper, ITokenManager tokenManager, InstanceEnvIdentity insEnvIdentity)
-			throws Exception {
-		this.factory = factory;
-		this.membership = membership;
-		this.config = config;
-		this.sleeper = sleeper;
-		this.tokenManager = tokenManager;
-		this.insEnvIdentity = insEnvIdentity;
-		init();
+    private final Predicate<AppsInstance> differentHostPredicate = new Predicate<AppsInstance>() {
+	@Override
+	public boolean apply(AppsInstance instance) {
+	    return (!instance.getInstanceId().equalsIgnoreCase(DUMMY_INSTANCE_ID)
+		    && !instance.getHostName().equals(myInstance.getHostName()));
 	}
+    };
 
-	public AppsInstance getInstance() {
-		return myInstance;
-	}
+    private AppsInstance myInstance;
+    private boolean isReplace = false;
+    private boolean isTokenPregenerated = false;
+    private String replacedIp = "";
 
-	public void init() throws Exception {
-		// try to grab the token which was already assigned
-		myInstance = new RetryableCallable<AppsInstance>() {
-			@Override
-			public AppsInstance retriableCall() throws Exception {
-				// Check if this node is decommissioned
-				for (AppsInstance ins : factory.getAllIds(config.getAppName() + "-dead")) {
-					logger.debug(String.format("[Dead] Iterating though the hosts: %s",
-							ins.getInstanceId()));
-					if (ins.getInstanceId().equals(config.getInstanceName())) {
-						ins.setOutOfService(true);
-						return ins;
-					}
-				}
-				for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
-					logger.debug(String
-							.format("[Alive] Iterating though the hosts: %s My id = [%s]",
-									ins.getInstanceId(), ins.getId()));
-					if (ins.getInstanceId().equals(config.getInstanceName()))
-						return ins;
-				}
-				return null;
-			}
-		}.call();
-		// Grab a dead token
-		if (null == myInstance)
-			myInstance = new GetDeadToken().call();
+    @Inject
+    public InstanceIdentity(IAppsInstanceFactory factory, IMembership membership, IConfiguration config,
+	    Sleeper sleeper, ITokenManager tokenManager, InstanceEnvIdentity insEnvIdentity) throws Exception {
+	this.factory = factory;
+	this.membership = membership;
+	this.config = config;
+	this.sleeper = sleeper;
+	this.tokenManager = tokenManager;
+	this.insEnvIdentity = insEnvIdentity;
+	init();
+    }
 
-		// Grab a pre-generated token if there is such one
-		if (null == myInstance)
-			myInstance = new GetPregeneratedToken().call();
+    public AppsInstance getInstance() {
+	return myInstance;
+    }
 
-		// Grab a new token
-		if (null == myInstance) {
-			GetNewToken newToken = new GetNewToken();
-			newToken.set(100, 100);
-			myInstance = newToken.call();
+    public void init() throws Exception {
+	// try to grab the token which was already assigned
+	myInstance = new RetryableCallable<AppsInstance>() {
+	    @Override
+	    public AppsInstance retriableCall() throws Exception {
+		// Check if this node is decommissioned
+		for (AppsInstance ins : factory.getAllIds(config.getAppName() + "-dead")) {
+		    logger.debug(String.format("[Dead] Iterating though the hosts: %s", ins.getInstanceId()));
+		    if (ins.getInstanceId().equals(config.getInstanceName())) {
+			ins.setOutOfService(true);
+			return ins;
+		    }
 		}
-		logger.info("My token: " + myInstance.getToken());
-
-	}
-
-	private void populateRacMap() {
-		locMap.clear();
 		for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
-			locMap.put(ins.getZone(), ins);
+		    logger.debug(String.format("[Alive] Iterating though the hosts: %s My id = [%s]",
+			    ins.getInstanceId(), ins.getId()));
+		    if (ins.getInstanceId().equals(config.getInstanceName()))
+			return ins;
 		}
+		return null;
+	    }
+	}.call();
+	// Grab a dead token
+	if (null == myInstance)
+	    myInstance = new GetDeadToken().call();
+
+	// Grab a pre-generated token if there is such one
+	if (null == myInstance)
+	    myInstance = new GetPregeneratedToken().call();
+
+	// Grab a new token
+	if (null == myInstance) {
+	    GetNewToken newToken = new GetNewToken();
+	    newToken.set(100, 100);
+	    myInstance = newToken.call();
+	}
+	logger.info("My token: " + myInstance.getToken());
+
+    }
+
+    private void populateRacMap() {
+	locMap.clear();
+	for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
+	    locMap.put(ins.getZone(), ins);
+	}
+    }
+
+    private List<String> getDualAccountRacMembership(List<String> asgInstances) {
+	logger.info("Dual Account cluster");
+
+	List<String> crossAccountAsgInstances = membership.getCrossAccountRacMembership();
+
+	if (insEnvIdentity.isClassic()) {
+	    logger.info("EC2 classic instances (local ASG): " + Arrays.toString(asgInstances.toArray()));
+	    logger.info("VPC Account (cross-account ASG): " + Arrays.toString(crossAccountAsgInstances.toArray()));
+	} else {
+	    logger.info("VPC Account (local ASG): " + Arrays.toString(asgInstances.toArray()));
+	    logger.info("EC2 classic instances (cross-account ASG): "
+		    + Arrays.toString(crossAccountAsgInstances.toArray()));
 	}
 
-	private List<String> getDualAccountRacMembership(List<String> asgInstances) {
-		logger.info("Dual Account cluster");
+	// Remove duplicates (probably there are not)
+	asgInstances.removeAll(crossAccountAsgInstances);
 
-		List<String> crossAccountAsgInstances = membership.getCrossAccountRacMembership();
+	// Merge the two lists
+	asgInstances.addAll(crossAccountAsgInstances);
+	logger.info("Combined Instances in the AZ: " + asgInstances);
 
-		if (insEnvIdentity.isClassic()) {
-			logger.info("EC2 classic instances (local ASG): " + Arrays.toString(asgInstances.toArray()));
-			logger.info("VPC Account (cross-account ASG): " + Arrays
-					.toString(crossAccountAsgInstances.toArray()));
-		} else {
-			logger.info("VPC Account (local ASG): " + Arrays.toString(asgInstances.toArray()));
-			logger.info("EC2 classic instances (cross-account ASG): " + Arrays
-					.toString(crossAccountAsgInstances.toArray()));
-		}
+	return asgInstances;
+    }
 
-		// Remove duplicates (probably there are not)
-		asgInstances.removeAll(crossAccountAsgInstances);
+    public class GetDeadToken extends RetryableCallable<AppsInstance> {
+	@Override
+	public AppsInstance retriableCall() throws Exception {
+	    final List<AppsInstance> allIds = factory.getAllIds(config.getAppName());
+	    List<String> asgInstances = membership.getRacMembership();
+	    if (config.isDualAccount()) {
+		asgInstances = getDualAccountRacMembership(asgInstances);
+	    } else {
+		logger.info("Single Account cluster");
+	    }
 
-		// Merge the two lists
-		asgInstances.addAll(crossAccountAsgInstances);
-		logger.info("Combined Instances in the AZ: " + asgInstances);
-
-		return asgInstances;
+	    // Sleep random interval - upto 15 sec
+	    sleeper.sleep(new Random().nextInt(5000) + 10000);
+	    for (AppsInstance dead : allIds) {
+		// test same dc and is it is alive.
+		if (!dead.getRack().equals(config.getRack()) || asgInstances.contains(dead.getInstanceId()))
+		    continue;
+		logger.info("Found dead instances: " + dead.getInstanceId());
+		// AppsInstance markAsDead = factory.create(dead.getApp() +
+		// "-dead", dead.getId(), dead.getInstanceId(),
+		// dead.getHostName(), dead.getHostIP(), dead.getZone(),
+		// dead.getVolumes(), dead.getToken(), dead.getRack());
+		// remove it as we marked it down...
+		// factory.delete(dead);
+		isReplace = true;
+		replacedIp = dead.getHostIP();
+		String payLoad = dead.getToken();
+		logger.info("Trying to grab slot {} with availability zone {}", dead.getId(), dead.getZone());
+		return factory.create(config.getAppName(), dead.getId(), config.getInstanceName(), config.getHostname(),
+			config.getHostIP(), config.getZone(), dead.getVolumes(), payLoad, config.getRack());
+	    }
+	    return null;
 	}
 
-	public class GetDeadToken extends RetryableCallable<AppsInstance> {
-		@Override
-		public AppsInstance retriableCall() throws Exception {
-			final List<AppsInstance> allIds = factory.getAllIds(config.getAppName());
-			List<String> asgInstances = membership.getRacMembership();
-			if (config.isDualAccount()) {
-				asgInstances = getDualAccountRacMembership(asgInstances);
-			} else {
-				logger.info("Single Account cluster");
-			}
+	public void forEachExecution() {
+	    populateRacMap();
+	}
+    }
 
-			// Sleep random interval - upto 15 sec
-			sleeper.sleep(new Random().nextInt(5000) + 10000);
-			for (AppsInstance dead : allIds) {
-				// test same dc and is it is alive.
-				if (!dead.getRack().equals(config.getRack()) || asgInstances
-						.contains(dead.getInstanceId()))
-					continue;
-				logger.info("Found dead instances: " + dead.getInstanceId());
-				//AppsInstance markAsDead = factory.create(dead.getApp() + "-dead", dead.getId(), dead.getInstanceId(), dead.getHostName(), dead.getHostIP(), dead.getZone(),
-				//                                         dead.getVolumes(), dead.getToken(), dead.getRack());
-				// remove it as we marked it down...
-				//factory.delete(dead);
-				isReplace = true;
-				replacedIp = dead.getHostIP();
-				String payLoad = dead.getToken();
-				logger.info("Trying to grab slot {} with availability zone {}", dead.getId(),
-						dead.getZone());
-				return factory.create(config.getAppName(), dead.getId(), config.getInstanceName(),
-						config.getHostname(), config.getHostIP(), config.getZone(),
-						dead.getVolumes(), payLoad, config.getRack());
-			}
-			return null;
-		}
+    public class GetPregeneratedToken extends RetryableCallable<AppsInstance> {
+	@Override
+	public AppsInstance retriableCall() throws Exception {
+	    logger.info("Looking for any pre-generated token");
+	    final List<AppsInstance> allIds = factory.getAllIds(config.getAppName());
+	    List<String> asgInstances = membership.getRacMembership();
+	    // Sleep random interval - upto 15 sec
+	    sleeper.sleep(new Random().nextInt(5000) + 10000);
+	    for (AppsInstance dead : allIds) {
+		// test same zone and is it is alive.
+		if (!dead.getRack().equals(config.getRack()) || asgInstances.contains(dead.getInstanceId())
+			|| !isInstanceDummy(dead))
+		    continue;
+		logger.info("Found pre-generated token: " + dead.getToken());
+		// AppsInstance markAsDead = factory.create(dead.getApp() +
+		// "-dead", dead.getId(), dead.getInstanceId(),
+		// dead.getHostName(), dead.getHostIP(), dead.getRack(),
+		// dead.getVolumes(),
+		// dead.getToken());
+		// remove it as we marked it down...
+		factory.delete(dead);
+		isTokenPregenerated = true;
 
-		public void forEachExecution() {
-			populateRacMap();
-		}
+		String payLoad = dead.getToken();
+		logger.info("Trying to grab slot {} with availability zone {}", dead.getId(), dead.getRack());
+		return factory.create(config.getAppName(), dead.getId(), config.getInstanceName(), config.getHostname(),
+			config.getHostIP(), config.getZone(), dead.getVolumes(), payLoad, config.getRack());
+	    }
+	    return null;
 	}
 
-	public class GetPregeneratedToken extends RetryableCallable<AppsInstance> {
-		@Override
-		public AppsInstance retriableCall() throws Exception {
-			logger.info("Looking for any pre-generated token");
-			final List<AppsInstance> allIds = factory.getAllIds(config.getAppName());
-			List<String> asgInstances = membership.getRacMembership();
-			// Sleep random interval - upto 15 sec
-			sleeper.sleep(new Random().nextInt(5000) + 10000);
-			for (AppsInstance dead : allIds) {
-				// test same zone and is it is alive.
-				if (!dead.getRack().equals(config.getRack()) || asgInstances
-						.contains(dead.getInstanceId()) || !isInstanceDummy(dead))
-					continue;
-				logger.info("Found pre-generated token: " + dead.getToken());
-				// AppsInstance markAsDead = factory.create(dead.getApp() + "-dead", dead.getId(), dead.getInstanceId(), dead.getHostName(), dead.getHostIP(), dead.getRack(), dead.getVolumes(),
-				//        dead.getToken());
-				// remove it as we marked it down...
-				factory.delete(dead);
-				isTokenPregenerated = true;
+	public void forEachExecution() {
+	    populateRacMap();
+	}
+    }
 
-				String payLoad = dead.getToken();
-				logger.info("Trying to grab slot {} with availability zone {}", dead.getId(),
-						dead.getRack());
-				return factory.create(config.getAppName(), dead.getId(), config.getInstanceName(),
-						config.getHostname(), config.getHostIP(), config.getZone(),
-						dead.getVolumes(), payLoad, config.getRack());
-			}
-			return null;
-		}
+    public class GetNewToken extends RetryableCallable<AppsInstance> {
 
-		public void forEachExecution() {
-			populateRacMap();
-		}
+	public AppsInstance retriableCall() throws Exception {
+	    // Sleep random interval - upto 15 sec
+	    sleeper.sleep(new Random().nextInt(15000));
+	    int hash = tokenManager.regionOffset(config.getRack());
+	    // use this hash so that the nodes are spred far away from the other
+	    // regions.
+	    String myInstanceId = config.getInstanceName();
+	    List<String> asgInstanceIds = membership.getRacMembership();
+
+	    logger.info("My Instance Id: " + myInstanceId);
+
+	    for (String instanceId : asgInstanceIds) {
+		logger.info("InstanceId in ASG: " + instanceId);
+	    }
+
+	    int my_slot = asgInstanceIds.indexOf(myInstanceId);
+	    logger.info("my_slot ::: " + my_slot);
+
+            int rackMembershipSize;
+            if (config.isDualAccount()){
+        	rackMembershipSize = membership.getRacMembershipSize() + membership.getCrossAccountRacMembershipSize();
+            }
+            else {
+        	rackMembershipSize = membership.getRacMembershipSize();
+            }
+            
+	    logger.info(String.format(
+		    "Trying to createToken with slot %d with rac count %d with rac membership size %d with dc %s",
+		    my_slot, membership.getRacCount(), rackMembershipSize, config.getRegion()));
+	    // String payload = tokenManager.createToken(my_slot,
+	    // membership.getRacCount(), membership.getRacMembershipSize(),
+	    // config.getDataCenter());
+	    String payload = tokenManager.createToken(my_slot, rackMembershipSize, config.getRack());
+	    return factory.create(config.getAppName(), my_slot + hash, config.getInstanceName(), config.getHostname(),
+		    config.getHostIP(), config.getZone(), null, payload, config.getRack());
 	}
 
-	public class GetNewToken extends RetryableCallable<AppsInstance> {
-
-		public AppsInstance retriableCall() throws Exception {
-			// Sleep random interval - upto 15 sec
-			sleeper.sleep(new Random().nextInt(15000));
-			int hash = tokenManager.regionOffset(config.getRack());
-			// use this hash so that the nodes are spred far away from the other
-			// regions.
-			String myInstanceId = config.getInstanceName();
-			List<String> asgInstanceIds = membership.getRacMembership();
-
-			logger.info("My Instance Id: " + myInstanceId);
-
-			for (String instanceId : asgInstanceIds) {
-				logger.info("InstanceId in ASG: " + instanceId);
-			}
-
-			int my_slot = asgInstanceIds.indexOf(myInstanceId);
-			logger.info("my_slot ::: " + my_slot);
-
-			logger.info(String
-					.format("Trying to createToken with slot %d with rac count %d with rac membership size %d with dc %s",
-							my_slot, membership.getRacCount(),
-							membership.getRacMembershipSize(), config.getRegion()));
-			//String payload = tokenManager.createToken(my_slot, membership.getRacCount(), membership.getRacMembershipSize(), config.getDataCenter());
-			String payload = tokenManager
-					.createToken(my_slot, membership.getRacMembershipSize(), config.getRack());
-			return factory.create(config.getAppName(), my_slot + hash, config.getInstanceName(),
-					config.getHostname(), config.getHostIP(), config.getZone(), null, payload,
-					config.getRack());
-		}
-
-		public void forEachExecution() {
-			populateRacMap();
-		}
+	public void forEachExecution() {
+	    populateRacMap();
 	}
+    }
 
     /*
-	public List<String> getSeeds1() throws UnknownHostException
-    {
-        populateRacMap();
-        List<String> seeds = new LinkedList<String>();
-        // Handle single zone deployment
-        if (config.getRacs().size() == 1)
-        {
-            // Return empty list if all nodes are not up
-            if (membership.getRacMembershipSize() != locMap.get(myInstance.getRac()).size())
-                return seeds;
-            // If seed node, return the next node in the list
-            //if (locMap.get(myInstance.getRac()).size() > 1 && locMap.get(myInstance.getRac()).get(0).getHostIP().equals(myInstance.getHostIP()))
-            //{
-                //seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName());
-            	//seedp.add(seed + ":" + config.getPeerListenerPort() + ":" + config.getDataCenter() + ":5622637");
-            seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName() + ":" + config.getPeerListenerPort() +
-            			  ":" + config.getDataCenter() + ":" + locMap.get(myInstance.getRac()).get(1).getToken());
-            //}
-        }
-        for (String loc : locMap.keySet())
-        {
-        		AppsInstance instance = Iterables.tryFind(locMap.get(loc), differentHostPredicate).orNull();
-        		if (instance != null)
-        		{
-        			//seeds.add(instance.getHostName());
-        			seeds.add(instance.getHostName() + ":" +
-        			          config.getPeerListenerPort() + ":" +
-        					  config.getDataCenter() + ":" +
-        			          instance.getToken());
-        		}
-        }
-        return seeds;
+     * public List<String> getSeeds1() throws UnknownHostException {
+     * populateRacMap(); List<String> seeds = new LinkedList<String>(); //
+     * Handle single zone deployment if (config.getRacs().size() == 1) { //
+     * Return empty list if all nodes are not up if
+     * (membership.getRacMembershipSize() !=
+     * locMap.get(myInstance.getRac()).size()) return seeds; // If seed node,
+     * return the next node in the list //if
+     * (locMap.get(myInstance.getRac()).size() > 1 &&
+     * locMap.get(myInstance.getRac()).get(0).getHostIP().equals(myInstance.
+     * getHostIP())) //{
+     * //seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName());
+     * //seedp.add(seed + ":" + config.getPeerListenerPort() + ":" +
+     * config.getDataCenter() + ":5622637");
+     * seeds.add(locMap.get(myInstance.getRac()).get(1).getHostName() + ":" +
+     * config.getPeerListenerPort() + ":" + config.getDataCenter() + ":" +
+     * locMap.get(myInstance.getRac()).get(1).getToken()); //} } for (String loc
+     * : locMap.keySet()) { AppsInstance instance =
+     * Iterables.tryFind(locMap.get(loc), differentHostPredicate).orNull(); if
+     * (instance != null) { //seeds.add(instance.getHostName());
+     * seeds.add(instance.getHostName() + ":" + config.getPeerListenerPort() +
+     * ":" + config.getDataCenter() + ":" + instance.getToken()); } } return
+     * seeds; }
+     */
+
+    public List<String> getSeeds() throws UnknownHostException {
+	// populateRacMap();
+	List<String> seeds = new LinkedList<String>();
+
+	for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
+	    if (!ins.getInstanceId().equals(myInstance.getInstanceId())) {
+		logger.debug("Adding node: " + ins.getInstanceId());
+		seeds.add(ins.getHostName() + ":" + config.getPeerListenerPort() + ":" + ins.getRack() + ":"
+			+ ins.getDatacenter() + ":" + ins.getToken());
+	    }
+	}
+
+	return seeds;
     }
-    */
 
-	public List<String> getSeeds() throws UnknownHostException {
-		//populateRacMap();
-		List<String> seeds = new LinkedList<String>();
+    public List<String> getClusterInfo() throws UnknownHostException {
+	List<String> nodes = new LinkedList<String>();
 
-		for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
-			if (!ins.getInstanceId().equals(myInstance.getInstanceId())) {
-				logger.debug("Adding node: " + ins.getInstanceId());
-				seeds.add(ins.getHostName() + ":" +
-						config.getPeerListenerPort() + ":" +
-						ins.getRack() + ":" +
-						ins.getDatacenter() + ":" +
-						ins.getToken());
-			}
-		}
+	for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
+	    logger.debug("Adding node: " + ins.getInstanceId());
+	    nodes.add("{" + "\"token\":" + "\"" + ins.getToken() + "\"," + "\"hostname\":" + "\"" + ins.getHostName()
+		    + "\"," + "\"rack\":" + "\"" + ins.getRack() + "\"," + "\"ip\":" + "\"" + ins.getHostIP() + "\","
+		    + "\"zone\":" + "\"" + ins.getZone() + "\"," + "\"dc\":" + "\"" + ins.getDatacenter() + "\"" + "}");
 
-		return seeds;
 	}
 
-	public List<String> getClusterInfo() throws UnknownHostException {
-		List<String> nodes = new LinkedList<String>();
+	return nodes;
+    }
 
-		for (AppsInstance ins : factory.getAllIds(config.getAppName())) {
-			logger.debug("Adding node: " + ins.getInstanceId());
-			nodes.add("{" +
-					"\"token\":" + "\"" + ins.getToken() + "\"," +
-					"\"hostname\":" + "\"" + ins.getHostName() + "\"," +
-					"\"rack\":" + "\"" + ins.getRack() + "\"," +
-					"\"ip\":" + "\"" + ins.getHostIP() + "\"," +
-					"\"zone\":" + "\"" + ins.getZone() + "\"," +
-					"\"dc\":" + "\"" + ins.getDatacenter() + "\"" +
-					"}");
+    public boolean isSeed() {
+	populateRacMap();
+	String ip = locMap.get(myInstance.getZone()).get(0).getHostName();
+	return myInstance.getHostName().equals(ip);
+    }
 
-		}
+    public boolean isReplace() {
+	return isReplace;
+    }
 
-		return nodes;
-	}
+    public boolean isTokenPregenerated() {
+	return isTokenPregenerated;
+    }
 
-	public boolean isSeed() {
-		populateRacMap();
-		String ip = locMap.get(myInstance.getZone()).get(0).getHostName();
-		return myInstance.getHostName().equals(ip);
-	}
+    public String getReplacedIp() {
+	return replacedIp;
+    }
 
-	public boolean isReplace() {
-		return isReplace;
-	}
+    public String getTokens() {
+	return myInstance.getToken();
+    }
 
-	public boolean isTokenPregenerated() {
-		return isTokenPregenerated;
-	}
-
-	public String getReplacedIp() {
-		return replacedIp;
-	}
-
-	public String getTokens() {
-		return myInstance.getToken();
-	}
-
-	private boolean isInstanceDummy(AppsInstance instance) {
-		return instance.getInstanceId().equals(DUMMY_INSTANCE_ID);
-	}
+    private boolean isInstanceDummy(AppsInstance instance) {
+	return instance.getInstanceId().equals(DUMMY_INSTANCE_ID);
+    }
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * The identity package consists of the following components.
  *
  * <ul> <li>IAppsInstanceFactory: Manage the Dynomite cluster topology registry. <li>InstanceEnvIdentity: Indicates the

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Start the Dynomite Manager server.
  */
 package com.netflix.dynomitemanager;

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/IConfiguration.java
@@ -83,6 +83,11 @@ public interface IConfiguration {
 	 * @return Get the Data Center name (or region for AWS)
 	 */
 	public String getRack();
+	
+	/**
+	 * @return Get the cross account rack if in dual account mode
+	 */
+	public String getCrossAccountRack();
 
 	public List<String> getRacks();
 
@@ -228,5 +233,6 @@ public interface IConfiguration {
 	public String getCommaSeparatedCassandraHostNames();
 
 	public boolean isEurekaHostSupplierEnabled();
+
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/aws/AWSMembership.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/aws/AWSMembership.java
@@ -40,13 +40,10 @@ import com.amazonaws.services.ec2.model.SecurityGroup;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.google.inject.Singleton;
 import com.netflix.dynomitemanager.identity.IMembership;
 import com.netflix.dynomitemanager.identity.InstanceEnvIdentity;
 import com.netflix.dynomitemanager.sidecore.IConfiguration;
 import com.netflix.dynomitemanager.sidecore.ICredential;
-import com.netflix.dynomitemanager.sidecore.config.InstanceDataRetriever;
-import com.netflix.dynomitemanager.sidecore.config.VpcInstanceDataRetriever;
 
 /**
  * Query Amazon auto scale group (ASG) for its members to provide:
@@ -59,288 +56,339 @@ import com.netflix.dynomitemanager.sidecore.config.VpcInstanceDataRetriever;
  */
 public class AWSMembership implements IMembership {
 
-	private static final Logger logger = LoggerFactory.getLogger(AWSMembership.class);
-	private final IConfiguration config;
-	private final ICredential provider;
-	private final ICredential crossAccountProvider;
-	private final InstanceEnvIdentity insEnvIdentity;
+    private static final Logger logger = LoggerFactory.getLogger(AWSMembership.class);
+    private final IConfiguration config;
+    private final ICredential provider;
+    private final ICredential crossAccountProvider;
+    private final InstanceEnvIdentity insEnvIdentity;
 
-	@Inject
-	public AWSMembership(IConfiguration config, ICredential provider,
-			@Named("awsroleassumption") ICredential crossAccountProvider,
-			InstanceEnvIdentity insEnvIdentity) {
-		this.config = config;
-		this.provider = provider;
-		this.crossAccountProvider = crossAccountProvider;
-		this.insEnvIdentity = insEnvIdentity;
+    @Inject
+    public AWSMembership(IConfiguration config, ICredential provider,
+	    @Named("awsroleassumption") ICredential crossAccountProvider, InstanceEnvIdentity insEnvIdentity) {
+	this.config = config;
+	this.provider = provider;
+	this.crossAccountProvider = crossAccountProvider;
+	this.insEnvIdentity = insEnvIdentity;
 
+    }
+
+    @Override
+    public List<String> getRacMembership() {
+	AmazonAutoScaling client = null;
+	try {
+	    client = getAutoScalingClient();
+	    DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
+		    .withAutoScalingGroupNames(config.getASGName());
+	    DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
+
+	    List<String> instanceIds = Lists.newArrayList();
+	    for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
+		for (Instance ins : asg.getInstances())
+		    if (!(ins.getLifecycleState().equalsIgnoreCase("Terminating")
+			    || ins.getLifecycleState().equalsIgnoreCase("shutting-down")
+			    || ins.getLifecycleState().equalsIgnoreCase("Terminated")))
+			instanceIds.add(ins.getInstanceId());
+	    }
+	    logger.info(String.format("Querying Amazon returned following instance in the ASG: %s --> %s",
+		    config.getRack(), StringUtils.join(instanceIds, ",")));
+	    return instanceIds;
+	} finally {
+	    if (client != null)
+		client.shutdown();
 	}
+    }
 
-	@Override
-	public List<String> getRacMembership() {
-		AmazonAutoScaling client = null;
-		try {
-			client = getAutoScalingClient();
-			DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
-					.withAutoScalingGroupNames(config.getASGName());
-			DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
+    @Override
+    public List<String> getCrossAccountRacMembership() {
+	AmazonAutoScaling client = null;
+	try {
+	    client = getCrossAccountAutoScalingClient();
+	    DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
+		    .withAutoScalingGroupNames(config.getASGName());
+	    DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
 
-			List<String> instanceIds = Lists.newArrayList();
-			for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
-				for (Instance ins : asg.getInstances())
-					if (!(ins.getLifecycleState().equalsIgnoreCase("Terminating") || ins
-							.getLifecycleState().equalsIgnoreCase("shutting-down") || ins
-							.getLifecycleState().equalsIgnoreCase("Terminated")))
-						instanceIds.add(ins.getInstanceId());
-			}
-			logger.info(String.format("Querying Amazon returned following instance in the ASG: %s --> %s",
-					config.getRack(), StringUtils.join(instanceIds, ",")));
-			return instanceIds;
-		} finally {
-			if (client != null)
-				client.shutdown();
+	    List<String> instanceIds = Lists.newArrayList();
+	    for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
+		for (Instance ins : asg.getInstances())
+		    if (!(ins.getLifecycleState().equalsIgnoreCase("Terminating")
+			    || ins.getLifecycleState().equalsIgnoreCase("shutting-down")
+			    || ins.getLifecycleState().equalsIgnoreCase("Terminated")))
+			instanceIds.add(ins.getInstanceId());
+	    }
+	    logger.info(String.format("Querying Amazon returned following instance in the cross-account ASG: %s --> %s",
+		    config.getRack(), StringUtils.join(instanceIds, ",")));
+	    return instanceIds;
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    /**
+     * Actual membership AWS source of truth...
+     */
+    @Override
+    public int getRacMembershipSize() {
+	AmazonAutoScaling client = null;
+	try {
+	    client = getAutoScalingClient();
+	    DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
+		    .withAutoScalingGroupNames(config.getASGName());
+	    DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
+	    int size = 0;
+	    for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
+		size += asg.getMaxSize();
+	    }
+	    logger.info(String.format("Query on ASG returning %d instances", size));
+	    return size;
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    /**
+     * Cross-account member of AWS
+     */
+    @Override
+    public int getCrossAccountRacMembershipSize() {
+	AmazonAutoScaling client = null;
+	try {
+	    client = getCrossAccountAutoScalingClient();
+	    DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
+		    .withAutoScalingGroupNames(config.getCrossAccountRack());
+	    DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
+	    int size = 0;
+	    for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
+		size += asg.getMaxSize();
+	    }
+	    logger.info(String.format("Query on cross account ASG returning %d instances", size));
+	    return size;
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    @Override
+    public int getRacCount() {
+	return config.getRacks().size();
+    }
+
+    /**
+     * Adding peers' IPs as ingress to the running instance SG. The running
+     * instance could be in "classic" or "vpc"
+     */
+    public void addACL(Collection<String> listIPs, int from, int to) {
+	AmazonEC2 client = null;
+	try {
+	    client = getEc2Client();
+	    List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
+	    ipPermissions.add(
+		    new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
+
+	    if (this.insEnvIdentity.isClassic()) {
+		client.authorizeSecurityGroupIngress(
+			new AuthorizeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
+		logger.info("Done adding ACL to classic: " + StringUtils.join(listIPs, ","));
+	    } else {
+		AuthorizeSecurityGroupIngressRequest sgIngressRequest = new AuthorizeSecurityGroupIngressRequest();
+		sgIngressRequest.withGroupId(getVpcGroupId()); // fetch SG group
+							       // id for VPC
+							       // account of the
+							       // running
+							       // instances.
+		client.authorizeSecurityGroupIngress(sgIngressRequest.withIpPermissions(ipPermissions)); // Adding
+													 // peers'
+													 // IPs
+													 // as
+													 // ingress
+													 // to
+													 // the
+													 // SG
+													 // that
+													 // the
+													 // running
+													 // instance
+													 // belongs
+													 // to
+		logger.info("Done adding ACL to vpc: " + StringUtils.join(listIPs, ","));
+	    }
+
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    /*
+     * @return SG group id for a group name, vpc account of the running
+     * instance.
+     */
+    protected String getVpcGroupId() {
+	AmazonEC2 client = null;
+	try {
+	    client = getEc2Client();
+	    Filter nameFilter = new Filter().withName("group-name").withValues(config.getACLGroupName()); // SG
+	    Filter vpcFilter = new Filter().withName("vpc-id").withValues(config.getVpcId());
+
+	    DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withFilters(nameFilter, vpcFilter);
+	    DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
+	    for (SecurityGroup group : result.getSecurityGroups()) {
+		logger.debug(String.format("got group-id:%s for group-name:%s,vpc-id:%s", group.getGroupId(),
+			config.getACLGroupName(), config.getVpcId()));
+		return group.getGroupId();
+	    }
+	    logger.error(String.format("unable to get group-id for group-name=%s vpc-id=%s", config.getACLGroupName(),
+		    config.getVpcId()));
+	    return "";
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    /**
+     * removes a iplist from the SG
+     */
+    public void removeACL(Collection<String> listIPs, int from, int to) {
+	AmazonEC2 client = null;
+	try {
+	    client = getEc2Client();
+	    List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
+	    ipPermissions.add(
+		    new IpPermission().withFromPort(from).withIpProtocol("tcp").withIpRanges(listIPs).withToPort(to));
+
+	    if (this.insEnvIdentity.isClassic()) {
+		client.revokeSecurityGroupIngress(
+			new RevokeSecurityGroupIngressRequest(config.getACLGroupName(), ipPermissions));
+		logger.info("Done removing from ACL within classic env for running instance: "
+			+ StringUtils.join(listIPs, ","));
+	    } else {
+		RevokeSecurityGroupIngressRequest req = new RevokeSecurityGroupIngressRequest();
+		req.withGroupId(getVpcGroupId()); // fetch SG group id for vpc
+						  // account of the running
+						  // instance.
+		client.revokeSecurityGroupIngress(req.withIpPermissions(ipPermissions)); // Adding
+											 // peers'
+											 // IPs
+											 // as
+											 // ingress
+											 // to
+											 // the
+											 // running
+											 // instance
+											 // SG
+		logger.info("Done removing from ACL within vpc env for running instance: "
+			+ StringUtils.join(listIPs, ","));
+	    }
+
+	} finally {
+	    if (client != null)
+		client.shutdown();
+	}
+    }
+
+    /**
+     * List SG ACL's
+     */
+    public List<String> listACL(int from, int to) {
+	AmazonEC2 client = null;
+	try {
+	    client = getEc2Client();
+	    List<String> ipPermissions = new ArrayList<String>();
+
+	    if (this.insEnvIdentity.isClassic()) {
+
+		DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest()
+			.withGroupNames(Arrays.asList(config.getACLGroupName()));
+		DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
+		for (SecurityGroup group : result.getSecurityGroups())
+		    for (IpPermission perm : group.getIpPermissions())
+			if (perm.getFromPort() == from && perm.getToPort() == to)
+			    ipPermissions.addAll(perm.getIpRanges());
+
+		logger.info("Fetch current permissions for classic env of running instance");
+	    } else {
+
+		Filter nameFilter = new Filter().withName("group-name").withValues(config.getACLGroupName());
+		String vpcid = config.getVpcId();
+		if (vpcid == null || vpcid.isEmpty()) {
+		    throw new IllegalStateException("vpcid is null even though instance is running in vpc.");
 		}
+
+		Filter vpcFilter = new Filter().withName("vpc-id").withValues(vpcid); // only
+										      // fetch
+										      // SG
+										      // for
+										      // the
+										      // vpc
+										      // id
+										      // of
+										      // the
+										      // running
+										      // instance
+		DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest().withFilters(nameFilter,
+			vpcFilter);
+		DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
+		for (SecurityGroup group : result.getSecurityGroups())
+		    for (IpPermission perm : group.getIpPermissions())
+			if (perm.getFromPort() == from && perm.getToPort() == to)
+			    ipPermissions.addAll(perm.getIpRanges());
+
+		logger.info("Fetch current permissions for vpc env of running instance");
+	    }
+
+	    return ipPermissions;
+	} finally {
+	    if (client != null)
+		client.shutdown();
 	}
+    }
 
-	@Override
-	public List<String> getCrossAccountRacMembership() {
-		AmazonAutoScaling client = null;
-		try {
-			client = getCrossAccountAutoScalingClient();
-			DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
-					.withAutoScalingGroupNames(config.getASGName());
-			DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
-
-			List<String> instanceIds = Lists.newArrayList();
-			for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
-				for (Instance ins : asg.getInstances())
-					if (!(ins.getLifecycleState().equalsIgnoreCase("Terminating") || ins
-							.getLifecycleState().equalsIgnoreCase("shutting-down") || ins
-							.getLifecycleState().equalsIgnoreCase("Terminated")))
-						instanceIds.add(ins.getInstanceId());
-			}
-			logger.info(String
-					.format("Querying Amazon returned following instance in the cross-account ASG: %s --> %s",
-							config.getRack(), StringUtils.join(instanceIds, ",")));
-			return instanceIds;
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
+    @Override
+    public void expandRacMembership(int count) {
+	AmazonAutoScaling client = null;
+	try {
+	    client = getAutoScalingClient();
+	    DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
+		    .withAutoScalingGroupNames(config.getASGName());
+	    DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
+	    AutoScalingGroup asg = res.getAutoScalingGroups().get(0);
+	    UpdateAutoScalingGroupRequest ureq = new UpdateAutoScalingGroupRequest();
+	    ureq.setAutoScalingGroupName(asg.getAutoScalingGroupName());
+	    ureq.setMinSize(asg.getMinSize() + 1);
+	    ureq.setMaxSize(asg.getMinSize() + 1);
+	    ureq.setDesiredCapacity(asg.getMinSize() + 1);
+	    client.updateAutoScalingGroup(ureq);
+	} finally {
+	    if (client != null)
+		client.shutdown();
 	}
+    }
 
-	/**
-	 * Actual membership AWS source of truth...
-	 */
-	@Override
-	public int getRacMembershipSize() {
-		AmazonAutoScaling client = null;
-		try {
-			client = getAutoScalingClient();
-			DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
-					.withAutoScalingGroupNames(config.getASGName());
-			DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
-			int size = 0;
-			for (AutoScalingGroup asg : res.getAutoScalingGroups()) {
-				size += asg.getMaxSize();
-			}
-			logger.info(String.format("Query on ASG returning %d instances", size));
-			return size;
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
+    protected AmazonAutoScaling getAutoScalingClient() {
+	AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
+	client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
+	return client;
+    }
 
-	@Override
-	public int getRacCount() {
-		return config.getRacks().size();
-	}
+    protected AmazonAutoScaling getCrossAccountAutoScalingClient() {
+	AmazonAutoScaling client = new AmazonAutoScalingClient(crossAccountProvider.getAwsCredentialProvider());
+	client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
+	return client;
+    }
 
-	/**
-	 * Adding peers' IPs as ingress to the running instance SG.  The running instance could be in "classic" or "vpc"
-	 */
-	public void addACL(Collection<String> listIPs, int from, int to) {
-		AmazonEC2 client = null;
-		try {
-			client = getEc2Client();
-			List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
-			ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp")
-					.withIpRanges(listIPs).withToPort(to));
+    protected AmazonEC2 getEc2Client() {
+	AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
+	client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
+	return client;
+    }
 
-			if (this.insEnvIdentity.isClassic()) {
-				client.authorizeSecurityGroupIngress(
-						new AuthorizeSecurityGroupIngressRequest(config.getACLGroupName(),
-								ipPermissions));
-				logger.info("Done adding ACL to classic: " + StringUtils.join(listIPs, ","));
-			} else {
-				AuthorizeSecurityGroupIngressRequest sgIngressRequest = new AuthorizeSecurityGroupIngressRequest();
-				sgIngressRequest.withGroupId(
-						getVpcGroupId()); //fetch SG group id for VPC account of the running instances.
-				client.authorizeSecurityGroupIngress(sgIngressRequest.withIpPermissions(
-						ipPermissions)); //Adding peers' IPs as ingress to the SG that the running instance belongs to
-				logger.info("Done adding ACL to vpc: " + StringUtils.join(listIPs, ","));
-			}
-
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
-
-	/*
-	 * @return SG group id for a group name, vpc account of the running instance.
-	 */
-	protected String getVpcGroupId() {
-		AmazonEC2 client = null;
-		try {
-			client = getEc2Client();
-			Filter nameFilter = new Filter().withName("group-name")
-					.withValues(config.getACLGroupName()); //SG
-			Filter vpcFilter = new Filter().withName("vpc-id").withValues(config.getVpcId());
-
-			DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest()
-					.withFilters(nameFilter, vpcFilter);
-			DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
-			for (SecurityGroup group : result.getSecurityGroups()) {
-				logger.debug(String.format("got group-id:%s for group-name:%s,vpc-id:%s",
-						group.getGroupId(), config.getACLGroupName(), config.getVpcId()));
-				return group.getGroupId();
-			}
-			logger.error(String.format("unable to get group-id for group-name=%s vpc-id=%s",
-					config.getACLGroupName(), config.getVpcId()));
-			return "";
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
-
-	/**
-	 * removes a iplist from the SG
-	 */
-	public void removeACL(Collection<String> listIPs, int from, int to) {
-		AmazonEC2 client = null;
-		try {
-			client = getEc2Client();
-			List<IpPermission> ipPermissions = new ArrayList<IpPermission>();
-			ipPermissions.add(new IpPermission().withFromPort(from).withIpProtocol("tcp")
-					.withIpRanges(listIPs).withToPort(to));
-
-			if (this.insEnvIdentity.isClassic()) {
-				client.revokeSecurityGroupIngress(
-						new RevokeSecurityGroupIngressRequest(config.getACLGroupName(),
-								ipPermissions));
-				logger.info("Done removing from ACL within classic env for running instance: "
-						+ StringUtils.join(listIPs, ","));
-			} else {
-				RevokeSecurityGroupIngressRequest req = new RevokeSecurityGroupIngressRequest();
-				req.withGroupId(getVpcGroupId());  //fetch SG group id for vpc account of the running instance.
-				client.revokeSecurityGroupIngress(req.withIpPermissions(
-						ipPermissions));  //Adding peers' IPs as ingress to the running instance SG
-				logger.info("Done removing from ACL within vpc env for running instance: " + StringUtils
-						.join(listIPs, ","));
-			}
-
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
-
-	/**
-	 * List SG ACL's
-	 */
-	public List<String> listACL(int from, int to) {
-		AmazonEC2 client = null;
-		try {
-			client = getEc2Client();
-			List<String> ipPermissions = new ArrayList<String>();
-
-			if (this.insEnvIdentity.isClassic()) {
-
-				DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest()
-						.withGroupNames(Arrays.asList(config.getACLGroupName()));
-				DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
-				for (SecurityGroup group : result.getSecurityGroups())
-					for (IpPermission perm : group.getIpPermissions())
-						if (perm.getFromPort() == from && perm.getToPort() == to)
-							ipPermissions.addAll(perm.getIpRanges());
-
-				logger.info("Fetch current permissions for classic env of running instance");
-			} else {
-
-				Filter nameFilter = new Filter().withName("group-name")
-						.withValues(config.getACLGroupName());
-				String vpcid = config.getVpcId();
-				if (vpcid == null || vpcid.isEmpty()) {
-					throw new IllegalStateException(
-							"vpcid is null even though instance is running in vpc.");
-				}
-
-				Filter vpcFilter = new Filter().withName("vpc-id")
-						.withValues(vpcid); //only fetch SG for the vpc id of the running instance
-				DescribeSecurityGroupsRequest req = new DescribeSecurityGroupsRequest()
-						.withFilters(nameFilter, vpcFilter);
-				DescribeSecurityGroupsResult result = client.describeSecurityGroups(req);
-				for (SecurityGroup group : result.getSecurityGroups())
-					for (IpPermission perm : group.getIpPermissions())
-						if (perm.getFromPort() == from && perm.getToPort() == to)
-							ipPermissions.addAll(perm.getIpRanges());
-
-				logger.info("Fetch current permissions for vpc env of running instance");
-			}
-
-			return ipPermissions;
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
-
-	@Override
-	public void expandRacMembership(int count) {
-		AmazonAutoScaling client = null;
-		try {
-			client = getAutoScalingClient();
-			DescribeAutoScalingGroupsRequest asgReq = new DescribeAutoScalingGroupsRequest()
-					.withAutoScalingGroupNames(config.getASGName());
-			DescribeAutoScalingGroupsResult res = client.describeAutoScalingGroups(asgReq);
-			AutoScalingGroup asg = res.getAutoScalingGroups().get(0);
-			UpdateAutoScalingGroupRequest ureq = new UpdateAutoScalingGroupRequest();
-			ureq.setAutoScalingGroupName(asg.getAutoScalingGroupName());
-			ureq.setMinSize(asg.getMinSize() + 1);
-			ureq.setMaxSize(asg.getMinSize() + 1);
-			ureq.setDesiredCapacity(asg.getMinSize() + 1);
-			client.updateAutoScalingGroup(ureq);
-		} finally {
-			if (client != null)
-				client.shutdown();
-		}
-	}
-
-	protected AmazonAutoScaling getAutoScalingClient() {
-		AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
-		client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
-		return client;
-	}
-
-	protected AmazonAutoScaling getCrossAccountAutoScalingClient() {
-		AmazonAutoScaling client = new AmazonAutoScalingClient(crossAccountProvider.getAwsCredentialProvider());
-		client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
-		return client;
-	}
-
-	protected AmazonEC2 getEc2Client() {
-		AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-		client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
-		return client;
-	}
-
-	protected AmazonEC2 getCrossAccountEc2Client() {
-		AmazonEC2 client = new AmazonEC2Client(crossAccountProvider.getAwsCredentialProvider());
-		client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
-		return client;
-	}
+    protected AmazonEC2 getCrossAccountEc2Client() {
+	AmazonEC2 client = new AmazonEC2Client(crossAccountProvider.getAwsCredentialProvider());
+	client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
+	return client;
+    }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Create and restore backups to/from AWS S3.
  */
 package com.netflix.dynomitemanager.sidecore.backup;

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Dynomite Manager configuration.
  */
 package com.netflix.dynomitemanager.sidecore;

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/Bootstrap.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/Bootstrap.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dynomitemanager.sidecore.storage;
 
 public enum Bootstrap {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/WarmBootstrapTask.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/WarmBootstrapTask.java
@@ -167,7 +167,7 @@ public class WarmBootstrapTask extends Task {
 	List<String> peers = new ArrayList<String>();
 
 	for (AppsInstance ins : instances) {
-	    logger.info("Instance's token(s); " + ins.getToken());
+            logger.info("Instance's token(s): " + ins.getToken() + " id: " + ins.getInstanceId());
 	    if (!ins.getRack().equals(ii.getInstance().getRack()) && ins.getToken().equals(tokens)) {
 		peers.add(ins.getHostName());
 	    }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Storage backends such as Redis.
  */
 package com.netflix.dynomitemanager.sidecore.storage;

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/supplier/package-info.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/supplier/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provide Dynomite Manager with a list of Cassandra hosts that store the complete Dynomite topology.
  */
 package com.netflix.dynomitemanager.supplier;

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FakeInstanceState.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/FakeInstanceState.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dynomitemanager.defaultimpl.test;
 
 import com.netflix.dynomitemanager.IInstanceState;

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -355,4 +355,10 @@ public class SimpleTestConfiguration implements IConfiguration {
 		return false;
 	}
 
+	@Override
+	public String getCrossAccountRack() {
+	    // TODO Auto-generated method stub
+	    return null;
+	}
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -355,4 +355,9 @@ public class BlankConfiguration implements IConfiguration {
 		return false;
 	}
 
+	@Override
+	public String getCrossAccountRack() {
+	    return null;
+	}
+
 }


### PR DESCRIPTION
This enhanced `dynomite-manager` to handle clusters that are in different AWS accounts. As of today, we were able to move a Dynomite cluster from a single AWS account to two AWS accounts, but we did not have the ability to deploy a Dynomite cluster across two accounts. This PR addresses this.