### PR TITLE
Centralize Redis and ARDB RocksDB config

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -739,4 +739,27 @@ public class DynomitemanagerConfiguration implements IConfiguration {
         return configSource.get(CONFIG_DYNO_REDIS_COMPATIBLE_SERVER, DEFAULT_REDIS_COMPATIBLE_SERVER);
     }
 
+    // ARDB RocksDB
+    // ============
+
+    @Override
+    public String getArdbRocksDBConf() {
+        String DEFAULT_ARDB_ROCKSDB_CONF = "/apps/ardb/conf/rocksdb.conf";
+        final String CONFIG_ARDB_ROCKSDB_CONF = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.conf";
+        return configSource.get(CONFIG_ARDB_ROCKSDB_CONF, DEFAULT_ARDB_ROCKSDB_CONF);
+    }
+
+    @Override
+    public String getArdbRocksDBInitStart() {
+        final String DEFAULT_ARDB_ROCKSDB_START_SCRIPT = "/apps/ardb/bin/launch_ardb.sh";
+        final String CONFIG_ARDB_ROCKSDB_START_SCRIPT = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.init.start";
+        return configSource.get(CONFIG_ARDB_ROCKSDB_START_SCRIPT, DEFAULT_ARDB_ROCKSDB_START_SCRIPT);
+    }
+
+    @Override
+    public String getArdbRocksDBInitStop() {
+        final String DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
+        final String CONFIG_ARDB_ROCKSDB_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.init.stop";
+        return configSource.get(CONFIG_ARDB_ROCKSDB_STOP_SCRIPT, DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT);
+    }
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -141,11 +141,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     private static final String CONFIG_RESTORE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.enabled";
     private static final String CONFIG_RESTORE_TIME = DYNOMITEMANAGER_PRE + ".dyno.backup.restore.date";
 
-    // persistence
-    private static final String CONFIG_PERSISTENCE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.persistence.enabled";
-    private static final String CONFIG_PERSISTENCE_TYPE = DYNOMITEMANAGER_PRE + ".dyno.persistence.type";
-    private static final String CONFIG_PERSISTENCE_DIR = DYNOMITEMANAGER_PRE + ".dyno.persistence.directory";
-
     // VPC
     private static final String CONFIG_INSTANCE_DATA_RETRIEVER = DYNOMITEMANAGER_PRE + ".instanceDataRetriever";
 
@@ -189,11 +184,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     private static final String DEFAULT_RESTORE_TIME = "20101010";
     private static final String DEFAULT_BACKUP_SCHEDULE = "day";
     private static final int DEFAULT_BACKUP_HOUR = 12;
-
-    // Persistence
-    private static final boolean DEFAULT_PERSISTENCE_ENABLED = false;
-    private static final String DEFAULT_PERSISTENCE_TYPE = "aof";
-    private static final String DEFAULT_PERSISTENCE_DIR = "/mnt/data/nfredis";
 
     // Redis compatible
     private static final String DEFAULT_REDIS_COMPATIBLE_ENGINE = "redis";
@@ -609,11 +599,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     // Backup & Restore Implementations
 
     @Override
-    public String getPersistenceLocation() {
-	return configSource.get(CONFIG_PERSISTENCE_DIR, DEFAULT_PERSISTENCE_DIR);
-    }
-
-    @Override
     public String getBucketName() {
 	return configSource.get(CONFIG_BUCKET_NAME, DEFAULT_BUCKET_NAME);
     }
@@ -653,26 +638,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     @Override
     public String getRestoreDate() {
 	return configSource.get(CONFIG_RESTORE_TIME, DEFAULT_RESTORE_TIME);
-    }
-
-    @Override
-    public boolean isPersistenceEnabled() {
-	return configSource.get(CONFIG_PERSISTENCE_ENABLED, DEFAULT_PERSISTENCE_ENABLED);
-    }
-
-    @Override
-    public boolean isAof() {
-
-	if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("rdb")) {
-	    return false;
-	} else if (configSource.get(CONFIG_PERSISTENCE_TYPE, DEFAULT_PERSISTENCE_TYPE).equals("aof")) {
-	    return true;
-	} else {
-	    logger.error("The persistence type FP is wrong: aof or rdb");
-	    logger.error("Defaulting to rdb");
-	    return false;
-	}
-
     }
 
     // VPC
@@ -746,4 +711,35 @@ public class DynomitemanagerConfiguration implements IConfiguration {
         final String CONFIG_REDIS_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".redis.init.stop";
         return configSource.get(CONFIG_REDIS_STOP_SCRIPT, DEFAULT_REDIS_STOP_SCRIPT);
     }
+
+    @Override
+    public boolean isRedisPersistenceEnabled() {
+        final boolean DEFAULT_REDIS_PERSISTENCE_ENABLED = false;
+        final String CONFIG_REDIS_PERSISTENCE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.persistence.enabled";
+        return configSource.get(CONFIG_REDIS_PERSISTENCE_ENABLED, DEFAULT_REDIS_PERSISTENCE_ENABLED);
+    }
+
+    @Override
+    public String getRedisDataDir() {
+        final String DEFAULT_REDIS_DATA_DIR = "/mnt/data/nfredis";
+        final String CONFIG_REDIS_DATA_DIR = DYNOMITEMANAGER_PRE + ".dyno.persistence.directory";
+        return configSource.get(CONFIG_REDIS_DATA_DIR, DEFAULT_REDIS_DATA_DIR);
+    }
+
+    @Override
+    public boolean isRedisAofEnabled() {
+        final String CONFIG_REDIS_PERSISTENCE_TYPE = DYNOMITEMANAGER_PRE + ".dyno.persistence.type";
+        final String DEFAULT_REDIS_PERSISTENCE_TYPE = "aof";
+
+        if (configSource.get(CONFIG_REDIS_PERSISTENCE_TYPE, DEFAULT_REDIS_PERSISTENCE_TYPE).equals("rdb")) {
+            return false;
+        } else if (configSource.get(CONFIG_REDIS_PERSISTENCE_TYPE, DEFAULT_REDIS_PERSISTENCE_TYPE).equals("aof")) {
+            return true;
+        } else {
+            logger.error("The persistence type FP is wrong: aof or rdb");
+            logger.error("Defaulting to rdb");
+            return false;
+        }
+    }
+
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -79,7 +79,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     private static final String CONFIG_DYNO_TOKENS_HASH_NAME = DYNOMITEMANAGER_PRE + ".dyno.tokens.hash";
     private static final String CONFIG_DYNO_CONNECTIONS_PRECONNECT = DYNOMITEMANAGER_PRE
 	    + ".dyno.connections.preconnect";
-    private static final String CONFIG_DYNO_REDIS_COMPATIBLE_ENGINE = DYNOMITEMANAGER_PRE + ".dyno.redis.compatible.engine";
     private static final String CONFIG_DYNO_IS_MULTI_REGIONED_CLUSTER = DYNOMITEMANAGER_PRE + ".dyno.multiregion";
     private static final String CONFIG_DYNO_HEALTHCHECK_ENABLE = DYNOMITEMANAGER_PRE + ".dyno.healthcheck.enable";
     // The max percentage of system memory to be allocated to the Dynomite
@@ -184,9 +183,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     private static final String DEFAULT_RESTORE_TIME = "20101010";
     private static final String DEFAULT_BACKUP_SCHEDULE = "day";
     private static final int DEFAULT_BACKUP_HOUR = 12;
-
-    // Redis compatible
-    private static final String DEFAULT_REDIS_COMPATIBLE_ENGINE = "redis";
 
     // AWS Dual Account
     private static final boolean DEFAULT_DUAL_ACCOUNT = false;
@@ -682,12 +678,6 @@ public class DynomitemanagerConfiguration implements IConfiguration {
 	return configSource.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
     }
 
-    // Redis compatibility
-    @Override
-    public String getRedisCompatibleEngine() {
-	return configSource.get(CONFIG_DYNO_REDIS_COMPATIBLE_ENGINE, DEFAULT_REDIS_COMPATIBLE_ENGINE);
-    }
-
     // Redis
     // =====
 
@@ -740,6 +730,13 @@ public class DynomitemanagerConfiguration implements IConfiguration {
             logger.error("Defaulting to rdb");
             return false;
         }
+    }
+
+    @Override
+    public String getRedisCompatibleServer() {
+        final String DEFAULT_REDIS_COMPATIBLE_SERVER = "redis";
+        final String CONFIG_DYNO_REDIS_COMPATIBLE_SERVER = DYNOMITEMANAGER_PRE + ".dyno.redis.compatible.engine";
+        return configSource.get(CONFIG_DYNO_REDIS_COMPATIBLE_SERVER, DEFAULT_REDIS_COMPATIBLE_SERVER);
     }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -726,16 +726,24 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     // Redis
     // =====
 
-    /**
-    * Get the full path to the redis.conf configuration file.
-    * Netflix:    /apps/nfredis/conf/redis.conf
-    * DynomiteDB: /etc/dynomitedb/redis.conf
-    * @return the {@link String} full path to the redis.conf configuration file
-    */
     @Override
     public String getRedisConf() {
         final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
         final String CONFIG_REDIS_CONF = DYNOMITEMANAGER_PRE + ".redis.conf";
         return configSource.get(CONFIG_REDIS_CONF, DEFAULT_REDIS_CONF);
+    }
+
+    @Override
+    public String getRedisInitStart() {
+        final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
+        final String CONFIG_REDIS_START_SCRIPT = DYNOMITEMANAGER_PRE + ".redis.init.start";
+        return configSource.get(CONFIG_REDIS_START_SCRIPT, DEFAULT_REDIS_START_SCRIPT);
+    }
+
+    @Override
+    public String getRedisInitStop() {
+        final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
+        final String CONFIG_REDIS_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".redis.init.stop";
+        return configSource.get(CONFIG_REDIS_STOP_SCRIPT, DEFAULT_REDIS_STOP_SCRIPT);
     }
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -261,8 +261,28 @@ public interface IConfiguration {
 	 * @return RESP backend server (redis, ardb-rocksdb)
      */
 	public String getRedisCompatibleServer();
-	// isBackendServer(REDIS)
-	// isBackendServer(ARDB_ROCKSDB)
-	// getBackendServer()
-	// isBackendServer(REDIS) { return getBackendServer().equals(REDIS) }
+
+	// ARDB RocksDB
+	// ============
+
+	/**
+	 * Get the full path to the rocksdb.conf configuration file.
+	 * Netflix:    /apps/ardb/conf/rocksdb.conf
+	 * DynomiteDB: /etc/dynomitedb/rocksdb.conf
+	 * @return the {@link String} full path to the rocksdb.conf configuration file
+	 */
+	public String getArdbRocksDBConf();
+
+	/**
+	 * Get the full path to the ARDB RocksDB init start script, including any arguments.
+	 * @return the full path of the ARDB RocksDB init start script
+	 */
+	public String getArdbRocksDBInitStart();
+
+	/**
+	 * Get the full path to the ARDB RocksDB init stop script, including any arguments.
+	 * @return the full path of the ARDB RocksDB init stop script
+	 */
+	public String getArdbRocksDBInitStop();
+
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -206,14 +206,6 @@ public interface IConfiguration {
 
 	public String getRestoreDate();
 
-	// Persistence
-
-	public String getPersistenceLocation();
-
-	public boolean isPersistenceEnabled();
-
-	public boolean isAof();
-
 	// Cassandra
 	public String getCassandraKeyspaceName();
 
@@ -237,15 +229,33 @@ public interface IConfiguration {
 	 */
 	public String getRedisConf();
 
-	/**
+    /**
 	 * Get the full path to the Redis init start script, including any arguments.
 	 * @return the full path of the Redis init start script
      */
-	public String getRedisInitStart();
+    public String getRedisInitStart();
 
 	/**
 	 * Get the full path to the Redis init stop script, including any arguments.
 	 * @return the full path of the Redis init stop script
+	 */
+    public String getRedisInitStop();
+
+	/**
+	 * Determines whether or not Redis will save data to disk.
+	 * @return true if Redis should persist in-memory data to disk or false if Redis should only store data in-memory
+	 */
+	public boolean isRedisPersistenceEnabled();
+
+	/**
+     * Get the full path to the directory where Redis stores its AOF or RDB data files.
+     * @return the full path to the directory where Redis stores its data files
      */
-	public String getRedisInitStop();
+    public String getRedisDataDir();
+
+	/**
+	 * Checks if Redis append-only file (AOF) persistence is enabled.
+	 * @return true to indicate that AOF persistence is enabled or false to indicate that RDB persistence is enabled
+	 */
+	public boolean isRedisAofEnabled();
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -215,9 +215,6 @@ public interface IConfiguration {
 
 	public boolean isEurekaHostSupplierEnabled();
 
-	// Redis compatible
-	public String getRedisCompatibleEngine();
-
 	// Redis
 	// =====
 
@@ -258,4 +255,14 @@ public interface IConfiguration {
 	 * @return true to indicate that AOF persistence is enabled or false to indicate that RDB persistence is enabled
 	 */
 	public boolean isRedisAofEnabled();
+
+	/**
+	 * Get the type of Redis compatible (RESP) backend server.
+	 * @return RESP backend server (redis, ardb-rocksdb)
+     */
+	public String getRedisCompatibleServer();
+	// isBackendServer(REDIS)
+	// isBackendServer(ARDB_ROCKSDB)
+	// getBackendServer()
+	// isBackendServer(REDIS) { return getBackendServer().equals(REDIS) }
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -229,5 +229,23 @@ public interface IConfiguration {
 	// Redis
 	// =====
 
+	/**
+	 * Get the full path to the redis.conf configuration file.
+	 * Netflix:    /apps/nfredis/conf/redis.conf
+	 * DynomiteDB: /etc/dynomitedb/redis.conf
+	 * @return the {@link String} full path to the redis.conf configuration file
+	 */
 	public String getRedisConf();
+
+	/**
+	 * Get the full path to the Redis init start script, including any arguments.
+	 * @return the full path of the Redis init start script
+     */
+	public String getRedisInitStart();
+
+	/**
+	 * Get the full path to the Redis init stop script, including any arguments.
+	 * @return the full path of the Redis init stop script
+     */
+	public String getRedisInitStop();
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Restore.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/S3Restore.java
@@ -78,10 +78,10 @@ public class S3Restore implements Restore {
 
 					String filepath = null;
 
-					if (config.isAof()) {
-						filepath = config.getPersistenceLocation() + "/appendonly.aof";
+					if (config.isRedisAofEnabled()) {
+						filepath = config.getRedisDataDir() + "/appendonly.aof";
 					} else {
-						filepath = config.getPersistenceLocation() + "/nfredis.rdb";
+						filepath = config.getRedisDataDir() + "/nfredis.rdb";
 					}
 
 					IOUtils.copy(s3object.getObjectContent(),

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/SnapshotTask.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/backup/SnapshotTask.java
@@ -99,10 +99,10 @@ public class SnapshotTask extends Task {
 					// the storage proxy takes a snapshot or compacts data
 					boolean snapshot = this.storageProxy.takeSnapshot();
 					File file = null;
-					if (config.isAof()) {
-						file = new File(config.getPersistenceLocation() + "/appendonly.aof");
+					if (config.isRedisAofEnabled()) {
+						file = new File(config.getRedisDataDir() + "/appendonly.aof");
 					} else {
-						file = new File(config.getPersistenceLocation() + "/nfredis.rdb");
+						file = new File(config.getRedisDataDir() + "/nfredis.rdb");
 					}
 					// upload the data to S3
 					if (file.length() > 0 && snapshot == true) {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/ArdbRocksDbRedisCompatible.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/ArdbRocksDbRedisCompatible.java
@@ -32,30 +32,35 @@ import com.google.common.base.Charsets;
 
 public class ArdbRocksDbRedisCompatible {
     final static String DYNO_ARDB_CONF_PATH = "/apps/ardb/conf/rocksdb.conf";
-    final static String ARDB_ROCKSDB_START_SCRIPT = "/apps/ardb/bin/launch_ardb.sh";
-    final static String ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
-    
+
     private static final Logger logger = LoggerFactory.getLogger(ArdbRocksDbRedisCompatible.class);
-    
+
+//    @Inject
+//    private IConfiguration config;
+
     public static void updateConfiguration(long storeMaxMem) throws IOException {
-	
+
 	/**
 	 * write_buffer_size = 512MB;
          * max_write_buffer_number = 5;
-         * 
+         *
          * We check if the memory is above 10GB and then allocate more max_write_buffer_number.
          * This approach is naive and should be optimized
-         * 
+         *
 	 */
 	int max_write_buffer_number = 5;
 	if (storeMaxMem > 10*1024*1024*1024) { // max storage memory
 	    max_write_buffer_number = 20;
 	}
-	
+
 
   	String ardbRedisCompatibleMode = "^redis-compatible-mode \\s*[a-zA-Z]*";
   	String maxWriteBufferNumber = ".max_write_buffer_number \\s*[a-zA-Z]*";
 
+        // TODO: Change to non-static
+//        logger.info("Updating ARDB/RocksDB conf: " + config.getArdbRocksDBConf());
+//        Path confPath = Paths.get(config.getArdbRocksDBConf());
+//        Path backupPath = Paths.get(config.getArdbRocksDBConf() + ".bkp");
   	logger.info("Updating ARDB/RocksDB conf: " + DYNO_ARDB_CONF_PATH);
   	Path confPath = Paths.get(DYNO_ARDB_CONF_PATH);
   	Path backupPath = Paths.get(DYNO_ARDB_CONF_PATH + ".bkp");
@@ -79,7 +84,7 @@ public class ArdbRocksDbRedisCompatible {
   		lines.set(i, compatibable);
   	    }
   	    else if(line.matches(maxWriteBufferNumber)) {
-  		String writeBufferNumber = "max_write_buffer_number=" + max_write_buffer_number + ";\\"; 
+  		String writeBufferNumber = "max_write_buffer_number=" + max_write_buffer_number + ";\\";
   		String padded = String.format("%-20s", writeBufferNumber);
   		logger.info("updatng options to: " + writeBufferNumber);
   		lines.set(i, padded);

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -691,7 +691,7 @@ public class RedisStorageProxy implements IStorageProxy {
     @Override
     public String getStartupScript() {
         if (config.getRedisCompatibleServer().equals(DYNO_ARDB_ROCKSDB)) {
-            return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_START_SCRIPT;
+            return config.getArdbRocksDBInitStart();
         }
 		return config.getRedisInitStart();
     }
@@ -699,7 +699,7 @@ public class RedisStorageProxy implements IStorageProxy {
     @Override
     public String getStopScript() {
         if (config.getRedisCompatibleServer().equals(DYNO_ARDB_ROCKSDB)) {
-            return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_STOP_SCRIPT;
+            return config.getArdbRocksDBInitStop();
         }
         return config.getRedisInitStop();
     }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -156,7 +156,7 @@ public class RedisStorageProxy implements IStorageProxy {
     public boolean takeSnapshot() {
 	localRedisConnect();
 	try {
-	    if (config.isAof()) {
+	    if (config.isRedisAofEnabled()) {
 		logger.info("starting Redis BGREWRITEAOF");
 		this.localJedis.bgrewriteaof();
 	    } else {
@@ -173,7 +173,7 @@ public class RedisStorageProxy implements IStorageProxy {
 	     */
 	} catch (JedisDataException e) {
 	    String scheduled = null;
-	    if (!config.isAof()) {
+	    if (!config.isRedisAofEnabled()) {
 		scheduled = "ERR Background save already in progress";
 	    } else {
 		scheduled = "ERR Background append only file rewriting already in progress";
@@ -195,8 +195,8 @@ public class RedisStorageProxy implements IStorageProxy {
 		String pendingPersistence = null;
 
 		for (String line : result) {
-		    if ((line.startsWith("aof_rewrite_in_progress") && config.isAof())
-			    || (line.startsWith("rdb_bgsave_in_progress") && !config.isAof())) {
+		    if ((line.startsWith("aof_rewrite_in_progress") && config.isRedisAofEnabled())
+			    || (line.startsWith("rdb_bgsave_in_progress") && !config.isRedisAofEnabled())) {
 			String[] items = line.split(":");
 			pendingPersistence = items[1].trim();
 			if (pendingPersistence.equals("0")) {
@@ -564,9 +564,9 @@ public class RedisStorageProxy implements IStorageProxy {
 		Files.copy(confPath, backupPath, COPY_ATTRIBUTES);
 	    }
 
-	    if (config.isPersistenceEnabled() && config.isAof()) {
+	    if (config.isRedisPersistenceEnabled() && config.isRedisAofEnabled()) {
 		logger.info("Persistence with AOF is enabled");
-	    } else if (config.isPersistenceEnabled() && !config.isAof()) {
+	    } else if (config.isRedisPersistenceEnabled() && !config.isRedisAofEnabled()) {
 		logger.info("Persistence with RDB is enabled");
 	    }
 
@@ -586,7 +586,7 @@ public class RedisStorageProxy implements IStorageProxy {
 		    lines.set(i, maxMemConf);
 		}
 		// Persistence configuration
-		if (config.isPersistenceEnabled() && config.isAof()) {
+		if (config.isRedisPersistenceEnabled() && config.isRedisAofEnabled()) {
 		    if (line.matches(REDIS_CONF_APPENDONLY)) {
 			String appendOnly = "appendonly yes";
 			logger.info("Updating Redis property: " + appendOnly);
@@ -608,7 +608,7 @@ public class RedisStorageProxy implements IStorageProxy {
 			logger.info("Updating Redis property: " + saveSchedule);
 			lines.set(i, saveSchedule);
 		    }
-		} else if (config.isPersistenceEnabled() && !config.isAof()) {
+		} else if (config.isRedisPersistenceEnabled() && !config.isRedisAofEnabled()) {
 		    if (line.matches(REDIS_CONF_STOP_WRITES_BGSAVE_ERROR)) {
 			String bgsaveerror = "stop-writes-on-bgsave-error no";
 			logger.info("Updating Redis property: " + bgsaveerror);

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -62,9 +62,6 @@ public class RedisStorageProxy implements IStorageProxy {
     private static final String PROC_MEMINFO_PATH = "/proc/meminfo";
     private static final Pattern MEMINFO_PATTERN = Pattern.compile("MemTotal:\\s*([0-9]*)");
 
-    private final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
-    private final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
-
     private static final String REDIS_CONF_MAXMEMORY_PATTERN = "^maxmemory\\s*[0-9][0-9]*[a-zA-Z]*";
     private static final String REDIS_CONF_APPENDONLY = "^appendonly\\s*[a-zA-Z]*";
     private static final String REDIS_CONF_APPENDFSYNC = "^ appendfsync\\s*[a-zA-Z]*";

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -550,7 +550,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
 	long storeMaxMem = getStoreMaxMem();
 
-	if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
+	if (config.getRedisCompatibleServer().equals(DYNO_ARDB_ROCKSDB)) {
 	    ArdbRocksDbRedisCompatible.updateConfiguration(storeMaxMem);
 	} else {
 	    // Updating the file.
@@ -690,7 +690,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
     @Override
     public String getStartupScript() {
-        if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
+        if (config.getRedisCompatibleServer().equals(DYNO_ARDB_ROCKSDB)) {
             return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_START_SCRIPT;
         }
 		return config.getRedisInitStart();
@@ -698,7 +698,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
     @Override
     public String getStopScript() {
-        if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
+        if (config.getRedisCompatibleServer().equals(DYNO_ARDB_ROCKSDB)) {
             return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_STOP_SCRIPT;
         }
         return config.getRedisInitStop();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -693,18 +693,18 @@ public class RedisStorageProxy implements IStorageProxy {
 
     @Override
     public String getStartupScript() {
-	if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
-	    return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_START_SCRIPT;
-	}
-	return DEFAULT_REDIS_START_SCRIPT;
+        if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
+            return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_START_SCRIPT;
+        }
+		return config.getRedisInitStart();
     }
 
     @Override
     public String getStopScript() {
-	if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
-	    return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_STOP_SCRIPT;
-	}
-	return DEFAULT_REDIS_STOP_SCRIPT;
+        if (config.getRedisCompatibleEngine().equals(DYNO_ARDB_ROCKSDB)) {
+            return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_STOP_SCRIPT;
+        }
+        return config.getRedisInitStop();
     }
 
     @Override

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -347,7 +347,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRedisCompatibleEngine() {
+	public String getRedisCompatibleServer() {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -356,4 +356,14 @@ public class SimpleTestConfiguration implements IConfiguration {
 	public String getRedisConf() {
 		return null;
 	}
+
+	@Override
+	public String getRedisInitStart() {
+		return null;
+	}
+
+	@Override
+	public String getRedisInitStop() {
+		return null;
+	}
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -366,4 +366,23 @@ public class SimpleTestConfiguration implements IConfiguration {
 	public String getRedisInitStop() {
 		return null;
 	}
+
+	// ARDB RocksDB
+	// ============
+
+	@Override
+	public String getArdbRocksDBConf() {
+		return null;
+	}
+
+	@Override
+	public String getArdbRocksDBInitStart() {
+		return null;
+	}
+
+	@Override
+	public String getArdbRocksDBInitStop() {
+		return null;
+	}
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -37,7 +37,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public boolean isPersistenceEnabled() {
+	public boolean isRedisPersistenceEnabled() {
 		return false;
 	}
 
@@ -62,7 +62,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public boolean isAof() {
+	public boolean isRedisAofEnabled() {
 		return false;
 	}
 
@@ -166,7 +166,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getPersistenceLocation() {
+	public String getRedisDataDir() {
 		return null;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -365,4 +365,23 @@ public class BlankConfiguration implements IConfiguration {
 	public String getRedisInitStop() {
 		return null;
 	}
+
+    // ARDB RocksDB
+    // ============
+
+    @Override
+    public String getArdbRocksDBConf() {
+        return null;
+    }
+
+    @Override
+    public String getArdbRocksDBInitStart() {
+        return null;
+    }
+
+    @Override
+    public String getArdbRocksDBInitStop() {
+        return null;
+    }
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -37,7 +37,7 @@ public class BlankConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public boolean isPersistenceEnabled() {
+	public boolean isRedisPersistenceEnabled() {
 		return false;
 	}
 
@@ -62,7 +62,7 @@ public class BlankConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public boolean isAof() {
+	public boolean isRedisAofEnabled() {
 		return false;
 	}
 
@@ -166,7 +166,7 @@ public class BlankConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getPersistenceLocation() {
+	public String getRedisDataDir() {
 		return null;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -346,7 +346,7 @@ public class BlankConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRedisCompatibleEngine() {
+	public String getRedisCompatibleServer() {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -355,4 +355,14 @@ public class BlankConfiguration implements IConfiguration {
 	public String getRedisConf() {
 		return null;
 	}
+
+	@Override
+	public String getRedisInitStart() {
+		return null;
+	}
+
+	@Override
+	public String getRedisInitStop() {
+		return null;
+	}
 }


### PR DESCRIPTION
1. Move Redis init scripts (start/stop) to DM config class
2. Remove old/unused redis init script constants
3. Rename and move Redis persistence config methods, constants
4. Centralize method to get the RESP backend type
5. Centralize ARDB RocksDB conf and init methods in DM configuration
6. Reformat entire ArdbRocksDbRedisCompatible.java file to use spaces not tabs