### PR TITLE
1. fix get region/dc bug 2. remove SimpleDB from default config sources

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/FloridaStandardTuner.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/FloridaStandardTuner.java
@@ -89,7 +89,7 @@ public class FloridaStandardTuner implements ProcessTuner {
 	entries.put("tokens", ii.getTokens());
 	entries.put("secure_server_option", config.getSecuredOption());
 	entries.remove("redis");
-	entries.put("datacenter", config.getRegion());
+	entries.put("datacenter", config.getDataCenter());
 	entries.put("read_consistency", config.getReadConsistency());
 	entries.put("write_consistency", config.getWriteConsistency());
 	entries.put("pem_key_file", "/apps/dynomite/conf/dynomite.pem");

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -61,17 +61,19 @@ public interface IConfiguration {
 	 */
 	public String getInstanceName();
 
-	/**
-	 * @return Get the Region name
-	 */
-	public String getRegion();
+    /**
+     * Get the data center (AWS region).
+     * @return the data center (AWS region)
+     */
+    public String getRegion();
 
 	//public void setRegion(String region);
 
-	/**
-	 * @return Get the Data Center name (or region for AWS)
-	 */
-	public String getRack();
+    /**
+     * Get the rack (AWS AZ).
+     * @return the rack (AWS AZ)
+     */
+    public String getRack();
 
 	/**
 	 * @return Get the cross account rack if in dual account mode

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -65,7 +65,7 @@ public interface IConfiguration {
      * Get the data center (AWS region).
      * @return the data center (AWS region)
      */
-    public String getRegion();
+    public String getDataCenter();
 
 	//public void setRegion(String region);
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/CassandraInstanceFactory.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/CassandraInstanceFactory.java
@@ -88,7 +88,7 @@ public class CassandraInstanceFactory implements IAppsInstanceFactory {
 			ins.setHostIP(ip);
 			ins.setId(id);
 			ins.setInstanceId(instanceID);
-			ins.setDatacenter(config.getRegion());
+			ins.setDatacenter(config.getDataCenter());
 			ins.setToken(payload);
 			ins.setVolumes(v);
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceIdentity.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceIdentity.java
@@ -266,10 +266,10 @@ public class InstanceIdentity {
             else {
         	rackMembershipSize = membership.getRacMembershipSize();
             }
-            
+
 	    logger.info(String.format(
 		    "Trying to createToken with slot %d with rac count %d with rac membership size %d with dc %s",
-		    my_slot, membership.getRacCount(), rackMembershipSize, config.getRegion()));
+		    my_slot, membership.getRacCount(), rackMembershipSize, config.getDataCenter()));
 	    // String payload = tokenManager.createToken(my_slot,
 	    // membership.getRacCount(), membership.getRacMembershipSize(),
 	    // config.getDataCenter());

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/DefaultConfigSource.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/DefaultConfigSource.java
@@ -21,18 +21,22 @@ import javax.inject.Inject;
  * Load Dynomite Manager's configuration from the following sources:
  *
  * <ul>
- * <li>{@link com.netflix.dynomitemanager.sidecore.SimpleDBConfigSource}
  * <li>{@link com.netflix.dynomitemanager.sidecore.PropertiesConfigSource}
  * <li>{@link com.netflix.dynomitemanager.sidecore.SystemPropertiesConfigSource}
  * </ul>
  */
 public class DefaultConfigSource extends CompositeConfigSource {
 
+    /**
+     * Provide list of configuration sources to check for properties (aka Fast Properties or FP).
+     * @param propertiesConfigSource the dynomitemanager.properties file
+     * @param systemPropertiesConfigSource Java properties passed on the command line via "-Dproperty=value"
+     */
 	@Inject
-	public DefaultConfigSource(final SimpleDBConfigSource simpleDBConfigSource,
-			final PropertiesConfigSource propertiesConfigSource,
+	public DefaultConfigSource(final PropertiesConfigSource propertiesConfigSource,
 			final SystemPropertiesConfigSource systemPropertiesConfigSource) {
-		super(simpleDBConfigSource, propertiesConfigSource, systemPropertiesConfigSource);
+
+		super(propertiesConfigSource, systemPropertiesConfigSource);
 	}
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/aws/AWSMembership.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/aws/AWSMembership.java
@@ -369,25 +369,25 @@ public class AWSMembership implements IMembership {
 
     protected AmazonAutoScaling getAutoScalingClient() {
 	AmazonAutoScaling client = new AmazonAutoScalingClient(provider.getAwsCredentialProvider());
-	client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
+	client.setEndpoint("autoscaling." + config.getDataCenter() + ".amazonaws.com");
 	return client;
     }
 
     protected AmazonAutoScaling getCrossAccountAutoScalingClient() {
 	AmazonAutoScaling client = new AmazonAutoScalingClient(crossAccountProvider.getAwsCredentialProvider());
-	client.setEndpoint("autoscaling." + config.getRegion() + ".amazonaws.com");
+	client.setEndpoint("autoscaling." + config.getDataCenter() + ".amazonaws.com");
 	return client;
     }
 
     protected AmazonEC2 getEc2Client() {
 	AmazonEC2 client = new AmazonEC2Client(provider.getAwsCredentialProvider());
-	client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
+	client.setEndpoint("ec2." + config.getDataCenter() + ".amazonaws.com");
 	return client;
     }
 
     protected AmazonEC2 getCrossAccountEc2Client() {
 	AmazonEC2 client = new AmazonEC2Client(crossAccountProvider.getAwsCredentialProvider());
-	client.setEndpoint("ec2." + config.getRegion() + ".amazonaws.com");
+	client.setEndpoint("ec2." + config.getDataCenter() + ".amazonaws.com");
 	return client;
     }
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/AwsInstanceDataRetriever.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/AwsInstanceDataRetriever.java
@@ -16,9 +16,18 @@ import com.netflix.dynomitemanager.sidecore.utils.SystemUtils;
 import com.netflix.dynomitemanager.sidecore.config.InstanceDataRetriever;
 
 /**
- * Calls AWS ec2 metadata to get info on the location of the running instance.
+ * Get AWS EC2 metadata for the current instance when the instance is in an AWS classic network.
  */
 public class AwsInstanceDataRetriever implements InstanceDataRetriever {
+
+    public String getDataCenter() {
+        String az = getRac();
+        String region = "";
+        if (az != null && az.length() > 0) {
+            region = az.substring(0, az.length()-1);
+        }
+        return region;
+    }
 
 	public String getRac() {
 		return SystemUtils

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/InstanceDataRetriever.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/InstanceDataRetriever.java
@@ -14,7 +14,18 @@
 package com.netflix.dynomitemanager.sidecore.config;
 
 public interface InstanceDataRetriever {
-	String getRac();
+
+    /**
+     * Get the data center (AWS region) for the current instance.
+     * @return the instance's data center (AWS region)
+     */
+    String getDataCenter();
+
+    /**
+     * Get the rack (AWS AZ) for the current instance.
+     * @return the instance's rack (AWS AZ)
+     */
+    String getRac();
 
 	String getPublicHostname();
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/LocalInstanceDataRetriever.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/LocalInstanceDataRetriever.java
@@ -21,6 +21,10 @@ package com.netflix.dynomitemanager.sidecore.config;
 public class LocalInstanceDataRetriever implements InstanceDataRetriever {
 	private static final String PREFIX = "dynomitemanager.localInstance.";
 
+    public String getDataCenter() {
+        return "us-east-1";
+    }
+
 	public String getRac() {
 		return "us-east-1c";
 	}

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/VpcInstanceDataRetriever.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/config/VpcInstanceDataRetriever.java
@@ -19,12 +19,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Calls AWS ec2 metadata to get info on the location of the running instance in VPC.
- * Public Hostname will return local-hostname
- * Public IP will return local-ipv4
+ * Get AWS EC2 metadata for the current instance when the instance is in an AWS VPC network.
  */
 public class VpcInstanceDataRetriever implements InstanceDataRetriever {
 	private static final Logger logger = LoggerFactory.getLogger(VpcInstanceDataRetriever.class);
+
+    public String getDataCenter() {
+        String az = getRac();
+        String region = "";
+        if (az != null && az.length() > 0) {
+            region = az.substring(0, az.length()-1);
+        }
+        return region;
+    }
 
 	public String getRac() {
 		return SystemUtils

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/WarmBootstrapTask.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/WarmBootstrapTask.java
@@ -162,7 +162,7 @@ public class WarmBootstrapTask extends Task {
 	String tokens = ii.getTokens();
 
 	logger.info("Warming up node's own token(s) : " + tokens);
-	List<AppsInstance> instances = appsInstanceFactory.getLocalDCIds(config.getAppName(), config.getRegion());
+	List<AppsInstance> instances = appsInstanceFactory.getLocalDCIds(config.getAppName(), config.getDataCenter());
 	List<String> peers = new ArrayList<String>();
 
 	for (AppsInstance ins : instances) {

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -136,7 +136,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRegion() {
+	public String getDataCenter() {
 		return null;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -136,7 +136,7 @@ public class BlankConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRegion() {
+	public String getDataCenter() {
 		return null;
 	}
 


### PR DESCRIPTION
1. `DynomitemanagerConfiguration` had a bug where `getRegion()` (renamed to `getDataCenter()`) only checked the `EC2_REGION` env var. 

The old `getRegion()` would return an empty region which would cause cascading failure.

I noticed the error when I got a null hostname exception by setting neither the `EC2_REGION` env var nor the value in a `.properties` file. However, EC2 metadata was returning the correct AZ, which was parsed to region, but was not used by `getRegion()`....thus the exception.

2. simple single file change to remove SimpleDB from default config source