### PR TITLE
Configuring RocksDB memory values dynamically

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomitemanagerConfiguration.java
@@ -143,6 +143,11 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     // VPC
     private static final String CONFIG_INSTANCE_DATA_RETRIEVER = DYNOMITEMANAGER_PRE + ".instanceDataRetriever";
 
+    // RocksDB 
+    private static final String CONFIG_WRITE_BUFFER_SIZE_MB = DYNOMITEMANAGER_PRE + ".dyno.ardb.rocksdb.writebuffermb";
+    private static final String CONFIG_MAX_WRITE_BUFFER_NUMBER = DYNOMITEMANAGER_PRE + ".dyno.ardb.rocksdb.maxwritebuffernumber";
+    private static final String CONFIG_MIN_WRITE_BUFFER_NAME_TO_MERGE = DYNOMITEMANAGER_PRE + ".dyno.ardb.rocksdb.minwritebuffernametomerge";
+    
     // Defaults
     private final String DEFAULT_CLUSTER_NAME = "dynomite_demo1";
     private final String DEFAULT_SEED_PROVIDER = "florida_provider";
@@ -183,6 +188,11 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     private static final String DEFAULT_RESTORE_TIME = "20101010";
     private static final String DEFAULT_BACKUP_SCHEDULE = "day";
     private static final int DEFAULT_BACKUP_HOUR = 12;
+    
+    // Ardb
+    private static final int DEFAULT_WRITE_BUFFER_SIZE_MB = 128; 
+    private static final int DEFAULT_MAX_WRITE_BUFFER_NUMBER = 16;
+    private static final int DEFAULT_MIN_WRITE_BUFFER_NAME_TO_MERGE = 4;
 
     // AWS Dual Account
     private static final boolean DEFAULT_DUAL_ACCOUNT = false;
@@ -642,8 +652,23 @@ public class DynomitemanagerConfiguration implements IConfiguration {
     }
 
     // VPC
+    @Override
     public String getVpcId() {
 	return NETWORK_VPC;
+    }
+    
+    // RocksDB
+    @Override
+    public int getWriteBufferSize() {
+	return configSource.get(CONFIG_WRITE_BUFFER_SIZE_MB,DEFAULT_WRITE_BUFFER_SIZE_MB);
+    }
+    
+    public int getMaxWriteBufferNumber() {
+	return configSource.get(CONFIG_MAX_WRITE_BUFFER_NUMBER,DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+    }
+    
+    public int getMinWriteBufferToMerge() {
+	return configSource.get(CONFIG_MIN_WRITE_BUFFER_NAME_TO_MERGE,DEFAULT_MIN_WRITE_BUFFER_NAME_TO_MERGE);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -19,272 +19,296 @@ import java.util.List;
  */
 public interface IConfiguration {
 
-	public void initialize();
+    public void initialize();
 
-	/**
-	 * @return Path to the home dir of target application
-	 */
-	public String getAppHome();
+    /**
+     * @return Path to the home dir of target application
+     */
+    public String getAppHome();
 
-	/**
-	 * @return Path to target application startup script
-	 */
-	public String getDynomiteStartupScript();
+    /**
+     * @return Path to target application startup script
+     */
+    public String getDynomiteStartupScript();
 
-	/**
-	 * @return Path to target application stop script
-	 */
-	public String getDynomiteStopScript();
+    /**
+     * @return Path to target application stop script
+     */
+    public String getDynomiteStopScript();
 
-	/**
-	 * @return Cluster name
-	 */
-	public String getAppName();
+    /**
+     * @return Cluster name
+     */
+    public String getAppName();
 
-	/**
-	 * @return Zone (or zone for AWS)
-	 */
-	public String getZone();
+    /**
+     * @return Zone (or zone for AWS)
+     */
+    public String getZone();
 
-	/**
-	 * @return List of all RAC used for the cluster
-	 */
-	public List<String> getZones();
+    /**
+     * @return List of all RAC used for the cluster
+     */
+    public List<String> getZones();
 
-	/**
-	 * @return Local hostname
-	 */
-	public String getHostname();
+    /**
+     * @return Local hostname
+     */
+    public String getHostname();
 
-	/**
-	 * @return Get instance name (for AWS)
-	 */
-	public String getInstanceName();
+    /**
+     * @return Get instance name (for AWS)
+     */
+    public String getInstanceName();
 
     /**
      * Get the data center (AWS region).
+     * 
      * @return the data center (AWS region)
      */
     public String getDataCenter();
 
-	//public void setRegion(String region);
+    // public void setRegion(String region);
 
     /**
      * Get the rack (AWS AZ).
+     * 
      * @return the rack (AWS AZ)
      */
     public String getRack();
 
-	/**
-	 * @return Get the cross account rack if in dual account mode
-	 */
-	public String getCrossAccountRack();
+    /**
+     * @return Get the cross account rack if in dual account mode
+     */
+    public String getCrossAccountRack();
 
-	public List<String> getRacks();
-
-	/**
-	 * Amazon specific setting to query ASG Membership
-	 */
-	public String getASGName();
-
-	/**
-	 * Get the security group associated with nodes in this cluster
-	 */
-	public String getACLGroupName();
-
-	/**
-	 * @return Get host IP
-	 */
-	public String getHostIP();
-
-	/**
-	 * @return Bootstrap cluster name (depends on another Cassandra cluster)
-	 */
-	public String getBootClusterName();
-
-	/**
-	 * @return Get the name of seed provider
-	 */
-	public String getSeedProviderName();
-
-	/**
-	 * @return Process Name
-	 */
-	public String getProcessName();
-
-	public String getReadConsistency();
-
-	public String getWriteConsistency();
-
-	public int getPeerListenerPort();
-
-	public int getSecuredPeerListenerPort();
-
-	public int getListenerPort();
-
-	public String getYamlLocation();
-
-	public boolean getAutoEjectHosts();
-
-	public String getDistribution();
-
-	public String getDynListenPort();
-
-	public int getGossipInterval();
-
-	public String getHash();
-
-	public String getClientListenPort();
-
-	public boolean getPreconnect();
-
-	public int getServerRetryTimeout();
-
-	public int getTimeout();
-
-	public String getTokens();
-
-	public String getMetadataKeyspace();
-
-	public boolean isMultiRegionedCluster();
-
-	public String getSecuredOption();
-
-	public boolean isWarmBootstrap();
-
-	public boolean isForceWarm();
-
-	public boolean isHealthCheckEnable();
-
-	public int getAllowableBytesSyncDiff();
-
-	public int getMaxTimeToBootstrap();
-
-	/**
-	 * @return the max percentage of system memory to be allocated to the Dynomite fronted data store.
-	 */
-	public int getStorageMemPercent();
-
-	public int getMbufSize();
-
-	public int getAllocatedMessages();
-
-	// VPC
-	public boolean isVpc();
-
-	/**
-	 * @return the VPC id of the running instance.
-	 */
-	public String getVpcId();
-
-	/*
-	 * @return the Amazon Resource Name (ARN) for EC2 classic.
-	 */
-	public String getClassicAWSRoleAssumptionArn();
-
-	/*
-	 * @return the Amazon Resource Name (ARN) for VPC.
-	 */
-	public String getVpcAWSRoleAssumptionArn();
-
-	/*
-	 * @return cross-account deployments
-	 */
-	public boolean isDualAccount();
-
-	// Backup and Restore
-
-	public String getBucketName();
-
-	public String getBackupLocation();
-
-	public boolean isBackupEnabled();
-
-	public boolean isRestoreEnabled();
-
-	public String getBackupSchedule();
-
-	public int getBackupHour();
-
-	public String getRestoreDate();
-
-	// Cassandra
-	public String getCassandraKeyspaceName();
-
-	public int getCassandraThriftPortForAstyanax();
-
-	public String getCommaSeparatedCassandraHostNames();
-
-	public boolean isEurekaHostSupplierEnabled();
-
-	// Redis
-	// =====
-
-	/**
-	 * Get the full path to the redis.conf configuration file.
-	 * Netflix:    /apps/nfredis/conf/redis.conf
-	 * DynomiteDB: /etc/dynomitedb/redis.conf
-	 * @return the {@link String} full path to the redis.conf configuration file
-	 */
-	public String getRedisConf();
+    public List<String> getRacks();
 
     /**
-	 * Get the full path to the Redis init start script, including any arguments.
-	 * @return the full path of the Redis init start script
+     * Amazon specific setting to query ASG Membership
+     */
+    public String getASGName();
+
+    /**
+     * Get the security group associated with nodes in this cluster
+     */
+    public String getACLGroupName();
+
+    /**
+     * @return Get host IP
+     */
+    public String getHostIP();
+
+    /**
+     * @return Bootstrap cluster name (depends on another Cassandra cluster)
+     */
+    public String getBootClusterName();
+
+    /**
+     * @return Get the name of seed provider
+     */
+    public String getSeedProviderName();
+
+    /**
+     * @return Process Name
+     */
+    public String getProcessName();
+
+    public String getReadConsistency();
+
+    public String getWriteConsistency();
+
+    public int getPeerListenerPort();
+
+    public int getSecuredPeerListenerPort();
+
+    public int getListenerPort();
+
+    public String getYamlLocation();
+
+    public boolean getAutoEjectHosts();
+
+    public String getDistribution();
+
+    public String getDynListenPort();
+
+    public int getGossipInterval();
+
+    public String getHash();
+
+    public String getClientListenPort();
+
+    public boolean getPreconnect();
+
+    public int getServerRetryTimeout();
+
+    public int getTimeout();
+
+    public String getTokens();
+
+    public String getMetadataKeyspace();
+
+    public boolean isMultiRegionedCluster();
+
+    public String getSecuredOption();
+
+    public boolean isWarmBootstrap();
+
+    public boolean isForceWarm();
+
+    public boolean isHealthCheckEnable();
+
+    public int getAllowableBytesSyncDiff();
+
+    public int getMaxTimeToBootstrap();
+
+    /**
+     * @return the max percentage of system memory to be allocated to the
+     *         Dynomite fronted data store.
+     */
+    public int getStorageMemPercent();
+
+    public int getMbufSize();
+
+    public int getAllocatedMessages();
+
+    // VPC
+    public boolean isVpc();
+
+    /**
+     * @return the VPC id of the running instance.
+     */
+    public String getVpcId();
+
+    /*
+     * @return the Amazon Resource Name (ARN) for EC2 classic.
+     */
+    public String getClassicAWSRoleAssumptionArn();
+
+    /*
+     * @return the Amazon Resource Name (ARN) for VPC.
+     */
+    public String getVpcAWSRoleAssumptionArn();
+
+    /*
+     * @return cross-account deployments
+     */
+    public boolean isDualAccount();
+
+    // Backup and Restore
+
+    public String getBucketName();
+
+    public String getBackupLocation();
+
+    public boolean isBackupEnabled();
+
+    public boolean isRestoreEnabled();
+
+    public String getBackupSchedule();
+
+    public int getBackupHour();
+
+    public String getRestoreDate();
+
+    // Cassandra
+    public String getCassandraKeyspaceName();
+
+    public int getCassandraThriftPortForAstyanax();
+
+    public String getCommaSeparatedCassandraHostNames();
+
+    public boolean isEurekaHostSupplierEnabled();
+
+    // Redis
+    // =====
+
+    /**
+     * Get the full path to the redis.conf configuration file. Netflix:
+     * /apps/nfredis/conf/redis.conf DynomiteDB: /etc/dynomitedb/redis.conf
+     * 
+     * @return the {@link String} full path to the redis.conf configuration file
+     */
+    public String getRedisConf();
+
+    /**
+     * Get the full path to the Redis init start script, including any
+     * arguments.
+     * 
+     * @return the full path of the Redis init start script
      */
     public String getRedisInitStart();
 
-	/**
-	 * Get the full path to the Redis init stop script, including any arguments.
-	 * @return the full path of the Redis init stop script
-	 */
+    /**
+     * Get the full path to the Redis init stop script, including any arguments.
+     * 
+     * @return the full path of the Redis init stop script
+     */
     public String getRedisInitStop();
 
-	/**
-	 * Determines whether or not Redis will save data to disk.
-	 * @return true if Redis should persist in-memory data to disk or false if Redis should only store data in-memory
-	 */
-	public boolean isRedisPersistenceEnabled();
+    /**
+     * Determines whether or not Redis will save data to disk.
+     * 
+     * @return true if Redis should persist in-memory data to disk or false if
+     *         Redis should only store data in-memory
+     */
+    public boolean isRedisPersistenceEnabled();
 
-	/**
-     * Get the full path to the directory where Redis stores its AOF or RDB data files.
+    /**
+     * Get the full path to the directory where Redis stores its AOF or RDB data
+     * files.
+     * 
      * @return the full path to the directory where Redis stores its data files
      */
     public String getRedisDataDir();
 
-	/**
-	 * Checks if Redis append-only file (AOF) persistence is enabled.
-	 * @return true to indicate that AOF persistence is enabled or false to indicate that RDB persistence is enabled
-	 */
-	public boolean isRedisAofEnabled();
-
-	/**
-	 * Get the type of Redis compatible (RESP) backend server.
-	 * @return RESP backend server (redis, ardb-rocksdb)
+    /**
+     * Checks if Redis append-only file (AOF) persistence is enabled.
+     * 
+     * @return true to indicate that AOF persistence is enabled or false to
+     *         indicate that RDB persistence is enabled
      */
-	public String getRedisCompatibleServer();
+    public boolean isRedisAofEnabled();
 
-	// ARDB RocksDB
-	// ============
+    /**
+     * Get the type of Redis compatible (RESP) backend server.
+     * 
+     * @return RESP backend server (redis, ardb-rocksdb)
+     */
+    public String getRedisCompatibleServer();
 
-	/**
-	 * Get the full path to the rocksdb.conf configuration file.
-	 * Netflix:    /apps/ardb/conf/rocksdb.conf
-	 * DynomiteDB: /etc/dynomitedb/rocksdb.conf
-	 * @return the {@link String} full path to the rocksdb.conf configuration file
-	 */
-	public String getArdbRocksDBConf();
+    // ARDB RocksDB
+    // ============
 
-	/**
-	 * Get the full path to the ARDB RocksDB init start script, including any arguments.
-	 * @return the full path of the ARDB RocksDB init start script
-	 */
-	public String getArdbRocksDBInitStart();
+    /**
+     * Get the full path to the rocksdb.conf configuration file. Netflix:
+     * /apps/ardb/conf/rocksdb.conf DynomiteDB: /etc/dynomitedb/rocksdb.conf
+     * 
+     * @return the {@link String} full path to the rocksdb.conf configuration
+     *         file
+     */
+    public String getArdbRocksDBConf();
 
-	/**
-	 * Get the full path to the ARDB RocksDB init stop script, including any arguments.
-	 * @return the full path of the ARDB RocksDB init stop script
-	 */
-	public String getArdbRocksDBInitStop();
+    /**
+     * Get the full path to the ARDB RocksDB init start script, including any
+     * arguments.
+     * 
+     * @return the full path of the ARDB RocksDB init start script
+     */
+    public String getArdbRocksDBInitStart();
+
+    /**
+     * Get the full path to the ARDB RocksDB init stop script, including any
+     * arguments.
+     * 
+     * @return the full path of the ARDB RocksDB init stop script
+     */
+    public String getArdbRocksDBInitStop();
+        
+    public int getWriteBufferSize();
+    
+    public int getMaxWriteBufferNumber();
+    
+    public int getMinWriteBufferToMerge();
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/ArdbRocksDbRedisCompatible.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/ArdbRocksDbRedisCompatible.java
@@ -23,12 +23,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
+import com.netflix.dynomitemanager.defaultimpl.IConfiguration;
 
 public class ArdbRocksDbRedisCompatible {
     final static String DYNO_ARDB_ROCKSDB = "ardb-rocksdb";
@@ -36,61 +38,144 @@ public class ArdbRocksDbRedisCompatible {
 
     private static final Logger logger = LoggerFactory.getLogger(ArdbRocksDbRedisCompatible.class);
 
-    //    @Inject
-    //    private IConfiguration config;
+    public static void updateConfiguration(long storeMaxMem, IConfiguration config) throws IOException {
 
-    public static void updateConfiguration(long storeMaxMem) throws IOException {
+ 	/**
+ 	 * --- ARDB configuration ----
+ 	 * 
+ 	 * rocksdb.options
+ 	 * write_buffer_size=512M;max_write_buffer_number=5;min_write_buffer_number_to_merge=2;compression=kSnappyCompression;\
+ 	 * bloom_locality=1;memtable_prefix_bloom_bits=100000000;memtable_prefix_bloom_probes=6;\
+ 	 * block_based_table_factory={block_cache=512M;filter_policy=bloomfilter:10:true};\
+ 	 * create_if_missing=true;max_open_files=10000;rate_limiter_bytes_per_sec=50M
+ 	 * 
+ 	 * write_buffer_size = 512MB; max_write_buffer_number = 5;
+ 	 * 
+ 	 * We check if the memory is above 10GB and then allocate more
+ 	 * max_write_buffer_number. This approach is naive and should be
+ 	 * optimized
+ 	 * 
+ 	 */
+ 	
+ 	int writeBufferSize = config.getWriteBufferSize();
+ 	int maxWriteBufferNumber = config.getMaxWriteBufferNumber();
+ 	if (writeBufferSize * maxWriteBufferNumber > storeMaxMem) {
+ 	    logger.warn("There is not enough memory in the instance. Using writeBufferSize = 128MB");
+ 	    writeBufferSize = 128;
+ 	    if (writeBufferSize * maxWriteBufferNumber > storeMaxMem) {
+ 		logger.warn("There is still not enough memory. Using maxWriteBufferNumber = 10");
+ 		maxWriteBufferNumber = 10;
+ 	    }
+ 	}
+ 	int minWriteBufferToMerge = config.getMinWriteBufferToMerge();
 
-        /*
-         * write_buffer_size = 512MB;
-         * max_write_buffer_number = 5;
-         *
-         * We check if the memory is above 10GB and then allocate more max_write_buffer_number.
-         * This approach is naive and should be optimized
-         *
-         */
-        int max_write_buffer_number = 5;
-        if (storeMaxMem > 10 * 1024 * 1024 * 1024) { // max storage memory
-            max_write_buffer_number = 20;
-        }
+ 	String rocksdbOptions = "rocksdb.options";
 
-        String ardbRedisCompatibleMode = "^redis-compatible-mode \\s*[a-zA-Z]*";
-        String maxWriteBufferNumber = ".max_write_buffer_number \\s*[a-zA-Z]*";
+ 	String ardbRedisCompatibleMode = "^redis-compatible-mode \\s*[a-zA-Z]*";
 
-        // TODO: Change to non-static
-        //        logger.info("Updating ARDB/RocksDB conf: " + config.getArdbRocksDBConf());
-        //        Path confPath = Paths.get(config.getArdbRocksDBConf());
-        //        Path backupPath = Paths.get(config.getArdbRocksDBConf() + ".bkp");
-        logger.info("Updating ARDB/RocksDB conf: " + DYNO_ARDB_CONF_PATH);
-        Path confPath = Paths.get(DYNO_ARDB_CONF_PATH);
-        Path backupPath = Paths.get(DYNO_ARDB_CONF_PATH + ".bkp");
-        // backup the original baked in conf only and not subsequent updates
-        if (!Files.exists(backupPath)) {
-            logger.info("Backing up baked in ARDB/RocksDB config at: " + backupPath);
-            Files.copy(confPath, backupPath, COPY_ATTRIBUTES);
-        }
+ 	logger.info("Updating ARDB/RocksDB conf: " + DYNO_ARDB_CONF_PATH);
+ 	Path confPath = Paths.get(DYNO_ARDB_CONF_PATH);
+ 	Path backupPath = Paths.get(DYNO_ARDB_CONF_PATH + ".bkp");
+ 	// backup the original baked in conf only and not subsequent updates
+ 	if (!Files.exists(backupPath)) {
+ 	    logger.info("Backing up baked in ARDB/RocksDB config at: " + backupPath);
+ 	    Files.copy(confPath, backupPath, COPY_ATTRIBUTES);
+ 	}
 
-        // Not using Properties file to load as we want to retain all comments,
-        // and for easy diffing with the ami baked version of the conf file.
-        List<String> lines = Files.readAllLines(confPath, Charsets.UTF_8);
-        for (int i = 0; i < lines.size(); i++) {
-            String line = lines.get(i);
-            if (line.startsWith("#")) {
-                continue;
-            }
-            if (line.matches(ardbRedisCompatibleMode)) {
-                String compatibable = "redis-compatible-mode yes";
-                logger.info("Updating ARDB property: " + compatibable);
-                lines.set(i, compatibable);
-            } else if (line.matches(maxWriteBufferNumber)) {
-                String writeBufferNumber = "max_write_buffer_number=" + max_write_buffer_number + ";\\";
-                String padded = String.format("%-20s", writeBufferNumber);
-                logger.info("updatng options to: " + writeBufferNumber);
-                lines.set(i, padded);
-            }
-        }
+ 	boolean rocksParse = false;
+ 	StringBuilder rocksProperties = new StringBuilder();
 
-        Files.write(confPath, lines, Charsets.UTF_8, WRITE, TRUNCATE_EXISTING);
-    }
+ 	// Not using Properties file to load as we want to retain all comments,
+ 	// and for easy diffing with the ami baked version of the conf file.
+ 	List<String> lines = Files.readAllLines(confPath, Charsets.UTF_8);
+ 	
+ 	// Create a new list to write back the file.
+ 	List<String> newLines = new ArrayList<String>();
 
-}
+ 	for (int i = 0; i < lines.size(); i++) {
+ 	    String line = lines.get(i);
+ 	    if (line.startsWith("#")) {
+ 		newLines.add(line);
+ 		continue;
+ 	    }
+ 	    if (line.matches(ardbRedisCompatibleMode)) {
+ 		String compatibable = "redis-compatible-mode yes";
+ 		logger.info("Updating ARDB property: " + compatibable);
+ 		newLines.add(compatibable);
+ 	    } else if (line.contains(rocksdbOptions)) {
+ 		rocksParse = true;
+ 		/*** KEY = rocksdb.options ***/
+ 		// split key and value pair of this line
+ 		String[] keyValue = line.split("\\s+");
+ 		rocksProperties.append(keyValue[1]);
+ 	    } else if (rocksParse) { // we need this for multi-line options parsing
+ 		// remove the empty space in the front and then append the value
+ 		rocksProperties.append(line.replaceAll("\\s", ""));
+
+ 		// last line of parsing rocksdb.options will not have ";\"
+ 		if (!line.contains("\\")) {
+ 		    // split the arguments based on the ";"
+ 		    String[] allProperties = rocksProperties.toString().split(";");
+
+ 		    // String builder to put the properties back
+ 		    StringBuilder newProperties = new StringBuilder();
+
+ 		    // parse the properties and replace
+ 		    for (String pr : allProperties) {
+ 			
+ 			boolean newLine = false;
+ 			// removing any prepending "\" in the properties
+ 			if (pr.contains("\\")) {
+ 			    pr = pr.replace("\\", "");
+ 			    newLine = true;
+ 			}
+ 			logger.info(pr);
+ 			// change the properties to the updated values
+ 			if (pr.contains("write_buffer_size")) {
+ 			    pr = "write_buffer_size=" + writeBufferSize + "MB";
+ 			    logger.info("property: " + pr);
+ 			} else if (pr.contains("max_write_buffer_number")) {
+ 			    pr = "max_write_buffer_number=" + maxWriteBufferNumber;
+ 			    logger.info("property: " + pr);
+ 			} else if (pr.contains("min_write_buffer_number_to_merge")) {
+ 			    pr = "min_write_buffer_number_to_merge=" + minWriteBufferToMerge;
+ 			    logger.info("updating property: " + pr);
+ 			}
+ 			/*
+ 			 * reconstructing 
+ 			 */
+ 			if (newLine == false) {
+ 			    newProperties.append(pr + ";");
+ 			}
+ 			else {
+ 			    newProperties.append(pr + ";\\" + System.lineSeparator() + spaces(30));
+ 			}
+ 		    }
+ 		    newLines.add("rocksdb.options" + spaces(15) + newProperties.toString());
+ 		    rocksParse = false;
+ 		}
+ 	    }
+ 	    else {
+ 		newLines.add(line);
+ 	    }
+ 	}
+
+ 	Files.write(confPath, newLines, Charsets.UTF_8, WRITE, TRUNCATE_EXISTING);
+     }
+     
+     private static String spaces(int numberOfSpaces)
+     {
+         //String builder is efficient at concatenating strings together
+         StringBuilder sb = new StringBuilder();
+
+         //Loop as many times as specified; each time add a space to the string
+         for(int i=0; i < numberOfSpaces; i++)
+         {
+             sb.append(" ");
+         }
+
+         //Return the string
+         return sb.toString();
+     }
+
+ }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -550,7 +550,7 @@ public class RedisStorageProxy implements IStorageProxy {
 	long storeMaxMem = getStoreMaxMem();
 
 	if (config.getRedisCompatibleServer().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB_ROCKSDB)) {
-	    ArdbRocksDbRedisCompatible.updateConfiguration(storeMaxMem);
+	    ArdbRocksDbRedisCompatible.updateConfiguration(storeMaxMem, config);
 	} else {
 	    // Updating the file.
 	    logger.info("Updating redis.conf: " + config.getRedisConf());

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -385,4 +385,19 @@ public class SimpleTestConfiguration implements IConfiguration {
 		return null;
 	}
 
+	@Override
+	public int getWriteBufferSize() {
+	    return 0;
+	}
+
+	@Override
+	public int getMaxWriteBufferNumber() {
+	    return 0;
+	}
+
+	@Override
+	public int getMinWriteBufferToMerge() {
+	    return 0;
+	}
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/monitoring/test/BlankConfiguration.java
@@ -21,367 +21,381 @@ import com.netflix.dynomitemanager.defaultimpl.IConfiguration;
  */
 public class BlankConfiguration implements IConfiguration {
 
-	@Override
-	public boolean isWarmBootstrap() {
-		return false;
-	}
-
-	@Override
-	public boolean isVpc() {
-		return false;
-	}
-
-	@Override
-	public boolean isRestoreEnabled() {
-		return false;
-	}
-
-	@Override
-	public boolean isRedisPersistenceEnabled() {
-		return false;
-	}
-
-	@Override
-	public boolean isMultiRegionedCluster() {
-		return false;
-	}
-
-	@Override
-	public boolean isHealthCheckEnable() {
-		return false;
-	}
-
-	@Override
-	public boolean isEurekaHostSupplierEnabled() {
-		return false;
-	}
-
-	@Override
-	public boolean isBackupEnabled() {
-		return false;
-	}
-
-	@Override
-	public boolean isRedisAofEnabled() {
-		return false;
-	}
-
-	@Override
-	public void initialize() {
-	}
-
-	@Override
-	public List<String> getZones() {
-		return null;
-	}
-
-	@Override
-	public String getZone() {
-		return null;
-	}
-
-	@Override
-	public String getYamlLocation() {
-		return null;
-	}
-
-	@Override
-	public String getWriteConsistency() {
-		return null;
-	}
-
-	@Override
-	public String getVpcId() {
-		return null;
-	}
-
-	@Override
-	public String getTokens() {
-		return null;
-	}
-
-	@Override
-	public int getTimeout() {
-		return 0;
-	}
-
-	@Override
-	public int getStorageMemPercent() {
-		return 0;
-	}
-
-	@Override
-	public int getServerRetryTimeout() {
-		return 0;
-	}
-
-	@Override
-	public String getSeedProviderName() {
-		return null;
-	}
-
-	@Override
-	public int getSecuredPeerListenerPort() {
-		return 0;
-	}
-
-	@Override
-	public String getSecuredOption() {
-		return null;
-	}
-
-	@Override
-	public String getRestoreDate() {
-		return null;
-	}
-
-	@Override
-	public String getDataCenter() {
-		return null;
-	}
-
-	@Override
-	public String getReadConsistency() {
-		return null;
-	}
-
-	@Override
-	public List<String> getRacks() {
-		return null;
-	}
-
-	@Override
-	public String getRack() {
-		return null;
-	}
-
-	@Override
-	public String getProcessName() {
-		return null;
-	}
-
-	@Override
-	public boolean getPreconnect() {
-		return false;
-	}
-
-	@Override
-	public String getRedisDataDir() {
-		return null;
-	}
-
-	@Override
-	public int getPeerListenerPort() {
-		return 0;
-	}
-
-	@Override
-	public String getMetadataKeyspace() {
-		return null;
-	}
-
-	@Override
-	public int getMbufSize() {
-		return 0;
-	}
-
-	@Override
-	public int getMaxTimeToBootstrap() {
-		return 0;
-	}
-
-	@Override
-	public int getListenerPort() {
-		return 0;
-	}
-
-	@Override
-	public String getInstanceName() {
-		return null;
-	}
-
-	@Override
-	public String getHostname() {
-		return null;
-	}
-
-	@Override
-	public String getHostIP() {
-		return null;
-	}
-
-	@Override
-	public String getHash() {
-		return null;
-	}
-
-	@Override
-	public int getGossipInterval() {
-		return 0;
-	}
-
-	@Override
-	public String getDynListenPort() {
-		return null;
-	}
-
-	@Override
-	public String getDistribution() {
-		return null;
-	}
-
-	@Override
-	public String getCommaSeparatedCassandraHostNames() {
-		return null;
-	}
-
-	@Override
-	public String getClientListenPort() {
-		return null;
-	}
-
-	@Override
-	public int getCassandraThriftPortForAstyanax() {
-		return 0;
-	}
-
-	@Override
-	public String getCassandraKeyspaceName() {
-		return null;
-	}
-
-	@Override
-	public String getBucketName() {
-		return null;
-	}
-
-	@Override
-	public String getBootClusterName() {
-		return null;
-	}
-
-	@Override
-	public String getBackupSchedule() {
-		return null;
-	}
-
-	@Override
-	public String getBackupLocation() {
-		return null;
-	}
-
-	@Override
-	public int getBackupHour() {
-		return 0;
-	}
-
-	@Override
-	public boolean getAutoEjectHosts() {
-		return false;
-	}
-
-	@Override
-	public String getDynomiteStopScript() {
-		return null;
-	}
-
-	@Override
-	public String getDynomiteStartupScript() {
-		return null;
-	}
-
-	@Override
-	public String getAppName() {
-		return null;
-	}
-
-	@Override
-	public String getAppHome() {
-		return null;
-	}
-
-	@Override
-	public int getAllowableBytesSyncDiff() {
-		return 0;
-	}
-
-	@Override
-	public int getAllocatedMessages() {
-		return 0;
-	}
-
-	@Override
-	public String getASGName() {
-		return null;
-	}
-
-	@Override
-	public String getACLGroupName() {
-		return null;
-	}
-
-	@Override
-	public String getClassicAWSRoleAssumptionArn() {
-		return null;
-	}
-
-	@Override
-	public String getVpcAWSRoleAssumptionArn() {
-		return null;
-	}
-
-	@Override
-	public boolean isDualAccount() {
-		return false;
-	}
-
-	@Override
-	public boolean isForceWarm() {
-		return false;
-	}
-
-	@Override
-	public String getCrossAccountRack() {
-		return null;
-	}
-
-	@Override
-	public String getRedisCompatibleServer() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public String getRedisConf() {
-		return null;
-	}
-
-	@Override
-	public String getRedisInitStart() {
-		return null;
-	}
-
-	@Override
-	public String getRedisInitStop() {
-		return null;
-	}
+    @Override
+    public boolean isWarmBootstrap() {
+	return false;
+    }
+
+    @Override
+    public boolean isVpc() {
+	return false;
+    }
+
+    @Override
+    public boolean isRestoreEnabled() {
+	return false;
+    }
+
+    @Override
+    public boolean isRedisPersistenceEnabled() {
+	return false;
+    }
+
+    @Override
+    public boolean isMultiRegionedCluster() {
+	return false;
+    }
+
+    @Override
+    public boolean isHealthCheckEnable() {
+	return false;
+    }
+
+    @Override
+    public boolean isEurekaHostSupplierEnabled() {
+	return false;
+    }
+
+    @Override
+    public boolean isBackupEnabled() {
+	return false;
+    }
+
+    @Override
+    public boolean isRedisAofEnabled() {
+	return false;
+    }
+
+    @Override
+    public void initialize() {
+    }
+
+    @Override
+    public List<String> getZones() {
+	return null;
+    }
+
+    @Override
+    public String getZone() {
+	return null;
+    }
+
+    @Override
+    public String getYamlLocation() {
+	return null;
+    }
+
+    @Override
+    public String getWriteConsistency() {
+	return null;
+    }
+
+    @Override
+    public String getVpcId() {
+	return null;
+    }
+
+    @Override
+    public String getTokens() {
+	return null;
+    }
+
+    @Override
+    public int getTimeout() {
+	return 0;
+    }
+
+    @Override
+    public int getStorageMemPercent() {
+	return 0;
+    }
+
+    @Override
+    public int getServerRetryTimeout() {
+	return 0;
+    }
+
+    @Override
+    public String getSeedProviderName() {
+	return null;
+    }
+
+    @Override
+    public int getSecuredPeerListenerPort() {
+	return 0;
+    }
+
+    @Override
+    public String getSecuredOption() {
+	return null;
+    }
+
+    @Override
+    public String getRestoreDate() {
+	return null;
+    }
+
+    @Override
+    public String getDataCenter() {
+	return null;
+    }
+
+    @Override
+    public String getReadConsistency() {
+	return null;
+    }
+
+    @Override
+    public List<String> getRacks() {
+	return null;
+    }
+
+    @Override
+    public String getRack() {
+	return null;
+    }
+
+    @Override
+    public String getProcessName() {
+	return null;
+    }
+
+    @Override
+    public boolean getPreconnect() {
+	return false;
+    }
+
+    @Override
+    public String getRedisDataDir() {
+	return null;
+    }
+
+    @Override
+    public int getPeerListenerPort() {
+	return 0;
+    }
+
+    @Override
+    public String getMetadataKeyspace() {
+	return null;
+    }
+
+    @Override
+    public int getMbufSize() {
+	return 0;
+    }
+
+    @Override
+    public int getMaxTimeToBootstrap() {
+	return 0;
+    }
+
+    @Override
+    public int getListenerPort() {
+	return 0;
+    }
+
+    @Override
+    public String getInstanceName() {
+	return null;
+    }
+
+    @Override
+    public String getHostname() {
+	return null;
+    }
+
+    @Override
+    public String getHostIP() {
+	return null;
+    }
+
+    @Override
+    public String getHash() {
+	return null;
+    }
+
+    @Override
+    public int getGossipInterval() {
+	return 0;
+    }
+
+    @Override
+    public String getDynListenPort() {
+	return null;
+    }
+
+    @Override
+    public String getDistribution() {
+	return null;
+    }
+
+    @Override
+    public String getCommaSeparatedCassandraHostNames() {
+	return null;
+    }
+
+    @Override
+    public String getClientListenPort() {
+	return null;
+    }
+
+    @Override
+    public int getCassandraThriftPortForAstyanax() {
+	return 0;
+    }
+
+    @Override
+    public String getCassandraKeyspaceName() {
+	return null;
+    }
+
+    @Override
+    public String getBucketName() {
+	return null;
+    }
+
+    @Override
+    public String getBootClusterName() {
+	return null;
+    }
+
+    @Override
+    public String getBackupSchedule() {
+	return null;
+    }
+
+    @Override
+    public String getBackupLocation() {
+	return null;
+    }
+
+    @Override
+    public int getBackupHour() {
+	return 0;
+    }
+
+    @Override
+    public boolean getAutoEjectHosts() {
+	return false;
+    }
+
+    @Override
+    public String getDynomiteStopScript() {
+	return null;
+    }
+
+    @Override
+    public String getDynomiteStartupScript() {
+	return null;
+    }
+
+    @Override
+    public String getAppName() {
+	return null;
+    }
+
+    @Override
+    public String getAppHome() {
+	return null;
+    }
+
+    @Override
+    public int getAllowableBytesSyncDiff() {
+	return 0;
+    }
+
+    @Override
+    public int getAllocatedMessages() {
+	return 0;
+    }
+
+    @Override
+    public String getASGName() {
+	return null;
+    }
+
+    @Override
+    public String getACLGroupName() {
+	return null;
+    }
+
+    @Override
+    public String getClassicAWSRoleAssumptionArn() {
+	return null;
+    }
+
+    @Override
+    public String getVpcAWSRoleAssumptionArn() {
+	return null;
+    }
+
+    @Override
+    public boolean isDualAccount() {
+	return false;
+    }
+
+    @Override
+    public boolean isForceWarm() {
+	return false;
+    }
+
+    @Override
+    public String getCrossAccountRack() {
+	return null;
+    }
+
+    @Override
+    public String getRedisCompatibleServer() {
+	return null;
+    }
+
+    @Override
+    public String getRedisConf() {
+	return null;
+    }
+
+    @Override
+    public String getRedisInitStart() {
+	return null;
+    }
+
+    @Override
+    public String getRedisInitStop() {
+	return null;
+    }
 
     // ARDB RocksDB
     // ============
 
     @Override
     public String getArdbRocksDBConf() {
-        return null;
+	return null;
     }
 
     @Override
     public String getArdbRocksDBInitStart() {
-        return null;
+	return null;
     }
 
     @Override
     public String getArdbRocksDBInitStop() {
-        return null;
+	return null;
+    }
+
+    @Override
+    public int getWriteBufferSize() {
+	return 0;
+    }
+
+    @Override
+    public int getMaxWriteBufferNumber() {
+	return 0;
+    }
+
+    @Override
+    public int getMinWriteBufferToMerge() {
+	return 0;
     }
 
 }


### PR DESCRIPTION
Adding three new fast properties (configurations) to allow the dynamic change of RocksDB memory configuration.
* `.dyno.ardb.rocksdb.writebuffermb`:  sets the size of a single memtable in MB.
* `.dyno.ardb.rocksdb.maxwritebuffernumber`: sets the maximum number of memtables, both active and immutable.
* `.dyno.ardb.rocksdb.minwritebuffernametomerge`: is the minimum number of memtables to be merged before flushing to storage.