### PR TITLE
Rename CassandraHostsSupplier to CassandraLocalHostsSupplier

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InjectedWebListener.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/InjectedWebListener.java
@@ -56,7 +56,7 @@ import com.netflix.dynomitemanager.sidecore.storage.IStorageProxy;
 import com.netflix.dynomitemanager.sidecore.storage.RedisStorageProxy;
 import com.netflix.dynomitemanager.sidecore.utils.FloridaHealthCheckHandler;
 import com.netflix.dynomitemanager.sidecore.utils.ProcessTuner;
-import com.netflix.dynomitemanager.supplier.CassandraHostsSupplier;
+import com.netflix.dynomitemanager.supplier.CassandraLocalHostsSupplier;
 import com.netflix.dynomitemanager.supplier.HostSupplier;
 import com.netflix.karyon.spi.HealthCheckHandler;
 import com.sun.jersey.api.core.PackagesResourceConfig;
@@ -127,7 +127,7 @@ public class InjectedWebListener extends GuiceServletContextListener {
 	    binder().bind(InstanceDataRetriever.class).to(VpcInstanceDataRetriever.class);
 	    // binder().bind(InstanceDataRetriever.class).to(LocalInstanceDataRetriever.class);
 	    // binder().bind(HostSupplier.class).to(EurekaHostsSupplier.class);
-	    binder().bind(HostSupplier.class).to(CassandraHostsSupplier.class);
+	    binder().bind(HostSupplier.class).to(CassandraLocalHostsSupplier.class);
 
 	    // binder().bind(InstanceEnvIdentity.class).to(LocalInstanceEnvIdentity.class);
 	    binder().bind(HealthCheckHandler.class).to(FloridaHealthCheckHandler.class).asEagerSingleton();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/supplier/CassandraLocalHostsSupplier.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/supplier/CassandraLocalHostsSupplier.java
@@ -31,13 +31,13 @@ import org.slf4j.LoggerFactory;
  * Use the {@code DM_CASSANDRA_CLUSTER_SEEDS} environment variable to provide a list of Cassandra hosts that contain the
  * complete Dynomite topology.
  */
-public class CassandraHostsSupplier implements HostSupplier {
-    private static final Logger logger = LoggerFactory.getLogger(CassandraHostsSupplier.class);
+public class CassandraLocalHostsSupplier implements HostSupplier {
+    private static final Logger logger = LoggerFactory.getLogger(CassandraLocalHostsSupplier.class);
     private static final String errMsg = "No Cassandra hosts were provided. Use DM_CASSANDRA_CLUSTER_SEEDS or configuration property getCassandraSeeds().";
 	private IConfiguration config;
 
 	@Inject
-	public CassandraHostsSupplier(IConfiguration config) {
+	public CassandraLocalHostsSupplier(IConfiguration config) {
 		this.config = config;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/supplier/test/CassandraLocalHostsSupplierTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/supplier/test/CassandraLocalHostsSupplierTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 import com.netflix.astyanax.connectionpool.Host;
 import com.netflix.dynomitemanager.monitoring.test.BlankConfiguration;
-import com.netflix.dynomitemanager.supplier.CassandraHostsSupplier;
+import com.netflix.dynomitemanager.supplier.CassandraLocalHostsSupplier;
 
 import static org.hamcrest.CoreMatchers.is;
 
@@ -29,11 +29,11 @@ import static org.hamcrest.CoreMatchers.is;
  * @author diegopacheco
  * @author akbarahmed
  */
-public class CassandraHostsSupplierTest {
+public class CassandraLocalHostsSupplierTest {
 
 	@Test
 	public void testSupplier() {
-		CassandraHostsSupplier lhs = new CassandraHostsSupplier(new BlankConfiguration());
+		CassandraLocalHostsSupplier lhs = new CassandraLocalHostsSupplier(new BlankConfiguration());
 		List<Host> hosts = lhs.getSupplier("DmClusterTest").get();
 		Assert.assertNotNull(hosts);
 		Assert.assertTrue(hosts.get(0) != null);


### PR DESCRIPTION
@ipapapa 

Rename CassandraHostsSupplier to CassandraLocalHostsSupplier.

I could not find any bug on the DEV branch in regards of CASS seeds. Looks all good to me.

Cheers,
Diego Pacheco