### PR TITLE
Archaius updates for Redis, ARDB, Eureka

### DIFF
--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -179,7 +179,10 @@ public class DynomiteManagerConfiguration implements IConfiguration {
             ARDB_ROCKSDB_PROPS + ".max.write.buffer.number";
     private static final String CONFIG_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE =
             ARDB_ROCKSDB_PROPS + ".min.write.buffer.number.to.merge";
+    private static final String CONFIG_ARDB_ROCKSDB_START_SCRIPT = ARDB_ROCKSDB_PROPS + ".start.script";
+    private static final String CONFIG_ARDB_ROCKSDB_STOP_SCRIPT = ARDB_ROCKSDB_PROPS + ".stop.script";
     private static final String CONFIG_WRITE_BUFFER_SIZE_MB = ARDB_ROCKSDB_PROPS + ".write.buffer.mb";
+
 
 
     // Eureka
@@ -294,6 +297,8 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String DEFAULT_ARDB_ROCKSDB_CONF = "/apps/ardb/conf/rocksdb.conf";
     private static final int DEFAULT_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER = 16;
     private static final int DEFAULT_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE = 4;
+    private static final String DEFAULT_ARDB_ROCKSDB_START_SCRIPT = "/apps/ardb/bin/launch_ardb.sh";
+    private static final String DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
     private static final int DEFAULT_WRITE_BUFFER_SIZE_MB = 128;
 
 
@@ -863,20 +868,6 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getArdbRocksDBInitStart() {
-        final String DEFAULT_ARDB_ROCKSDB_START_SCRIPT = "/apps/ardb/bin/launch_ardb.sh";
-        final String CONFIG_ARDB_ROCKSDB_START_SCRIPT = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.init.start";
-        return configSource.get(CONFIG_ARDB_ROCKSDB_START_SCRIPT, DEFAULT_ARDB_ROCKSDB_START_SCRIPT);
-    }
-
-    @Override
-    public String getArdbRocksDBInitStop() {
-        final String DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
-        final String CONFIG_ARDB_ROCKSDB_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.init.stop";
-        return configSource.get(CONFIG_ARDB_ROCKSDB_STOP_SCRIPT, DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT);
-    }
-
-    @Override
     public int getArdbRocksDBMaxWriteBufferNumber() {
         return getIntProperty("DM_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER", CONFIG_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER,
                 DEFAULT_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER);
@@ -886,6 +877,18 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public int getArdbRocksDBMinWriteBuffersToMerge() {
         return getIntProperty("DM_ARDB_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE",
                 CONFIG_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE, DEFAULT_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE);
+    }
+
+    @Override
+    public String getArdbRocksDBStartScript() {
+        return getStringProperty("DM_ARDB_ROCKSDB_START_SCRIPT", CONFIG_ARDB_ROCKSDB_START_SCRIPT,
+                DEFAULT_ARDB_ROCKSDB_START_SCRIPT);
+    }
+
+    @Override
+    public String getArdbRocksDBStopScript() {
+        return getStringProperty("DM_ARDB_ROCKSDB_STOP_SCRIPT", CONFIG_ARDB_ROCKSDB_STOP_SCRIPT,
+                DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -171,8 +171,13 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // The max percentage of system memory to be allocated to the backend data storage engine (ex. Redis, ARDB).
     private static final String CONFIG_DATASTORE_MAX_MEMORY_PERCENT = DATASTORE_PROPS + ".max.memory.percent";
 
-    // Storage engine: ARDB with RocksDB
-    // =================================
+    // Data store: Redis
+    // =================
+
+    private static final String CONFIG_REDIS_CONF = REDIS_PROPS + ".conf";
+
+    // Data store: ARDB with RocksDB
+    // =============================
 
     private static final String CONFIG_ARDB_ROCKSDB_CONF = ARDB_ROCKSDB_PROPS + ".conf";
     private static final String CONFIG_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER =
@@ -291,8 +296,13 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String DEFAULT_CASSANDRA_SEEDS = "127.0.0.1"; // comma separated list
     private static final int DEFAULT_CASSANDRA_THRIFT_PORT = 9160; // 7102;
 
-    // Defaults: Storage engine: ARDB with RocksDB
-    // ===========================================
+    // Defaults: Data store: Redis
+    // ===========================
+
+    private static final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
+
+    // Defaults: Data store: ARDB with RocksDB
+    // =======================================
 
     private static final String DEFAULT_ARDB_ROCKSDB_CONF = "/apps/ardb/conf/rocksdb.conf";
     private static final int DEFAULT_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER = 16;
@@ -798,14 +808,12 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 	return configSource.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
     }
 
-    // Redis
-    // =====
+    // Data store: Redis
+    // =================
 
     @Override
     public String getRedisConf() {
-        final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
-        final String CONFIG_REDIS_CONF = DYNOMITEMANAGER_PRE + ".redis.conf";
-        return configSource.get(CONFIG_REDIS_CONF, DEFAULT_REDIS_CONF);
+        return getStringProperty("DM_REDIS_CONF", CONFIG_REDIS_CONF, DEFAULT_REDIS_CONF);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -168,6 +168,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // Data store (aka backend)
     // ========================
 
+    private static final String CONFIG_DATASTORE_ENGINE = DATASTORE_PROPS + ".engine";
     // The max percentage of system memory to be allocated to the backend data storage engine (ex. Redis, ARDB).
     private static final String CONFIG_DATASTORE_MAX_MEMORY_PERCENT = DATASTORE_PROPS + ".max.memory.percent";
 
@@ -300,6 +301,12 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String DEFAULT_CASSANDRA_KEYSPACE_NAME = "dyno_bootstrap";
     private static final String DEFAULT_CASSANDRA_SEEDS = "127.0.0.1"; // comma separated list
     private static final int DEFAULT_CASSANDRA_THRIFT_PORT = 9160; // 7102;
+
+    // Defaults: Data store
+    // ====================
+
+    private static final String DEFAULT_DATASTORE_ENGINE = "redis";
+    private static final int DEFAULT_DATASTORE_MAX_MEMORY_PERCENT = 85;
 
     // Defaults: Data store: Redis
     // ===========================
@@ -702,14 +709,6 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 	return configSource.get(CONFIG_DYNO_MAX_TIME_BOOTSTRAP, 900000);
     }
 
-    // Data store (aka backend)
-    // ========================
-
-    @Override
-    public int getDatastoreMaxMemoryPercent() {
-        return getIntProperty("DM_DATASTORE_MAX_MEMORY_PERCENT", CONFIG_DATASTORE_MAX_MEMORY_PERCENT, 85);
-    }
-
     public boolean isVpc() {
 	return configSource.get(CONFIG_VPC, false);
     }
@@ -818,6 +817,20 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 	return configSource.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
     }
 
+    // Data store (aka backend)
+    // ========================
+
+    @Override
+    public String getDatastoreEngine() {
+        return getStringProperty("DM_DATASTORE_ENGINE", CONFIG_DATASTORE_ENGINE, DEFAULT_DATASTORE_ENGINE);
+    }
+
+    @Override
+    public int getDatastoreMaxMemoryPercent() {
+        return getIntProperty("DM_DATASTORE_MAX_MEMORY_PERCENT", CONFIG_DATASTORE_MAX_MEMORY_PERCENT,
+                DEFAULT_DATASTORE_MAX_MEMORY_PERCENT);
+    }
+
     // Data store: Redis
     // =================
 
@@ -867,13 +880,6 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public boolean isRedisPersistenceEnabled() {
         return getBooleanProperty("DM_REDIS_PERSISTENCE_ENABLED", CONFIG_REDIS_PERSISTENCE_ENABLED,
                 DEFAULT_REDIS_PERSISTENCE_ENABLED);
-    }
-
-    @Override
-    public String getRedisCompatibleEngine() {
-        final String DEFAULT_REDIS_COMPATIBLE_SERVER = "redis";
-        final String CONFIG_DYNO_REDIS_COMPATIBLE_SERVER = DYNOMITEMANAGER_PRE + ".dyno.redis.compatible.engine";
-        return configSource.get(CONFIG_DYNO_REDIS_COMPATIBLE_SERVER, DEFAULT_REDIS_COMPATIBLE_SERVER);
     }
 
     // Data store: ARDB with RocksDB

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -181,7 +181,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
             ARDB_ROCKSDB_PROPS + ".min.write.buffer.number.to.merge";
     private static final String CONFIG_ARDB_ROCKSDB_START_SCRIPT = ARDB_ROCKSDB_PROPS + ".start.script";
     private static final String CONFIG_ARDB_ROCKSDB_STOP_SCRIPT = ARDB_ROCKSDB_PROPS + ".stop.script";
-    private static final String CONFIG_WRITE_BUFFER_SIZE_MB = ARDB_ROCKSDB_PROPS + ".write.buffer.mb";
+    private static final String CONFIG_ARDB_ROCKSDB_WRITE_BUFFER_SIZE = ARDB_ROCKSDB_PROPS + ".write.buffer.size";
 
 
 
@@ -299,7 +299,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final int DEFAULT_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE = 4;
     private static final String DEFAULT_ARDB_ROCKSDB_START_SCRIPT = "/apps/ardb/bin/launch_ardb.sh";
     private static final String DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
-    private static final int DEFAULT_WRITE_BUFFER_SIZE_MB = 128;
+    private static final int DEFAULT_ARDB_ROCKSDB_WRITE_BUFFER_SIZE = 128; // MB
 
 
     private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
@@ -859,8 +859,8 @@ public class DynomiteManagerConfiguration implements IConfiguration {
         return configSource.get(CONFIG_DYNO_REDIS_COMPATIBLE_SERVER, DEFAULT_REDIS_COMPATIBLE_SERVER);
     }
 
-    // Storage engine: ARDB with RocksDB
-    // =================================
+    // Data store: ARDB with RocksDB
+    // =============================
 
     @Override
     public String getArdbRocksDBConf() {
@@ -892,8 +892,9 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getWriteBufferSize() {
-        return configSource.get(CONFIG_WRITE_BUFFER_SIZE_MB,DEFAULT_WRITE_BUFFER_SIZE_MB);
+    public int getArdbRocksDBWriteBufferSize() {
+        return getIntProperty("DM_ARDB_ROCKSDB_WRITE_BUFFER_SIZE", CONFIG_ARDB_ROCKSDB_WRITE_BUFFER_SIZE,
+                DEFAULT_ARDB_ROCKSDB_WRITE_BUFFER_SIZE);
     }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -63,10 +63,10 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public static final String REDIS_PREFIX = "redis";
     public static final String ARDB_PREFIX = "ardb";
     public static final String ROCKSDB_PREFIX = "rocksdb";
-    public static final String STORAGE_PREFIX = "storage"; // Storage engine (aka backend)
+    public static final String DATASTORE_PREFIX = "datastore"; // Storage engine (aka backend)
 
     public static final String DYNOMITE_PROPS = DYNOMITEMANAGER_PRE + "." + DYNOMITE_PREFIX;
-    public static final String STORAGE_PROPS = DYNOMITEMANAGER_PRE + "." + STORAGE_PREFIX;
+    public static final String DATASTORE_PROPS = DYNOMITEMANAGER_PRE + "." + DATASTORE_PREFIX;
     public static final String REDIS_PROPS = DYNOMITEMANAGER_PRE + "." + REDIS_PREFIX;
     public static final String ARDB_PROPS = DYNOMITEMANAGER_PRE + "." + ARDB_PREFIX;
     public static final String ARDB_ROCKSDB_PROPS = ARDB_PROPS + "." + ROCKSDB_PREFIX;
@@ -165,11 +165,11 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String CONFIG_CASSANDRA_SEEDS = CASSANDRA_PROPS + ".seeds";
     private static final String CONFIG_CASSANDRA_THRIFT_PORT = CASSANDRA_PROPS + ".thrift.port";
 
-    // Storage engine (aka backend)
-    // ============================
+    // Data store (aka backend)
+    // ========================
 
     // The max percentage of system memory to be allocated to the backend data storage engine (ex. Redis, ARDB).
-    private static final String CONFIG_STORAGE_MAX_MEMORY_PERCENT = STORAGE_PROPS + ".max.memory.percent";
+    private static final String CONFIG_DATASTORE_MAX_MEMORY_PERCENT = DATASTORE_PROPS + ".max.memory.percent";
 
     // Storage engine: ARDB with RocksDB
     // =================================
@@ -675,12 +675,12 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 	return configSource.get(CONFIG_DYNO_MAX_TIME_BOOTSTRAP, 900000);
     }
 
-    // Storage engine (aka backend)
-    // ============================
+    // Data store (aka backend)
+    // ========================
 
     @Override
-    public int getStorageMaxMemoryPercent() {
-        return getIntProperty("DM_STORAGE_MAX_MEMORY_PERCENT", CONFIG_STORAGE_MAX_MEMORY_PERCENT, 85);
+    public int getDatastoreMaxMemoryPercent() {
+        return getIntProperty("DM_DATASTORE_MAX_MEMORY_PERCENT", CONFIG_DATASTORE_MAX_MEMORY_PERCENT, 85);
     }
 
     public boolean isVpc() {

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -60,17 +60,25 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public static final String DYNOMITEMANAGER_PRE = "dm";
     public static final String CASSANDRA_PREFIX = "cassandra";
     public static final String DYNOMITE_PREFIX = "dynomite";
+    public static final String EUREKA_PREFIX = "eureka";
     public static final String REDIS_PREFIX = "redis";
     public static final String ARDB_PREFIX = "ardb";
     public static final String ROCKSDB_PREFIX = "rocksdb";
     public static final String DATASTORE_PREFIX = "datastore"; // Storage engine (aka backend)
+    public static final String AWS_PREFIX = "aws";
+    public static final String AZURE_PREFIX = "azure";
+    public static final String GCP_PREFIX = "gcp";
 
     public static final String DYNOMITE_PROPS = DYNOMITEMANAGER_PRE + "." + DYNOMITE_PREFIX;
     public static final String DATASTORE_PROPS = DYNOMITEMANAGER_PRE + "." + DATASTORE_PREFIX;
+    public static final String EUREKA_PROPS = DYNOMITEMANAGER_PRE + "." + EUREKA_PREFIX;
     public static final String REDIS_PROPS = DYNOMITEMANAGER_PRE + "." + REDIS_PREFIX;
     public static final String ARDB_PROPS = DYNOMITEMANAGER_PRE + "." + ARDB_PREFIX;
     public static final String ARDB_ROCKSDB_PROPS = ARDB_PROPS + "." + ROCKSDB_PREFIX;
     public static final String CASSANDRA_PROPS = DYNOMITEMANAGER_PRE + "." + CASSANDRA_PREFIX;
+    public static final String AWS_PROPS = DYNOMITEMANAGER_PRE + "." + AWS_PREFIX;
+    public static final String AZURE_PROPS = DYNOMITEMANAGER_PRE + "." + AZURE_PREFIX;
+    public static final String GCP_PROPS = DYNOMITEMANAGER_PRE + "." + GCP_PREFIX;
 
     // Archaius
     // ========
@@ -194,11 +202,10 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String CONFIG_ARDB_ROCKSDB_STOP_SCRIPT = ARDB_ROCKSDB_PROPS + ".stop.script";
     private static final String CONFIG_ARDB_ROCKSDB_WRITE_BUFFER_SIZE = ARDB_ROCKSDB_PROPS + ".write.buffer.size";
 
-
-
     // Eureka
-    private static final String CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED = DYNOMITEMANAGER_PRE
-	    + ".eureka.host.supplier.enabled";
+    // ======
+
+    private static final String CONFIG_EUREKA_HOSTS_SUPPLIER_ENABLED = EUREKA_PROPS + ".hosts.supplier.enabled";
 
     // Amazon specific
     private static final String CONFIG_ASG_NAME = DYNOMITEMANAGER_PRE + ".az.asgname";
@@ -328,8 +335,10 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     private static final String DEFAULT_ARDB_ROCKSDB_STOP_SCRIPT = "/apps/ardb/bin/kill_ardb.sh";
     private static final int DEFAULT_ARDB_ROCKSDB_WRITE_BUFFER_SIZE = 128; // MB
 
+    // Defaults: Eureka
+    // ================
 
-    private static final boolean DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED = true;
+    private static final boolean DEFAULT_EUREKA_HOSTS_SUPPLIER_ENABLED = true;
 
     // = instance identity meta data
     private String RAC, ZONE, PUBLIC_HOSTNAME, PUBLIC_IP, INSTANCE_ID, INSTANCE_TYPE;
@@ -810,13 +819,6 @@ public class DynomiteManagerConfiguration implements IConfiguration {
         return getIntProperty("DM_CASSANDRA_THRIFT_PORT", CONFIG_CASSANDRA_THRIFT_PORT, DEFAULT_CASSANDRA_THRIFT_PORT);
     }
 
-
-
-    @Override
-    public boolean isEurekaHostSupplierEnabled() {
-	return configSource.get(CONFIG_IS_EUREKA_HOST_SUPPLIER_ENABLED, DEFAULT_IS_EUREKA_HOST_SUPPLIER_ENABLED);
-    }
-
     // Data store (aka backend)
     // ========================
 
@@ -918,6 +920,15 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public int getArdbRocksDBWriteBufferSize() {
         return getIntProperty("DM_ARDB_ROCKSDB_WRITE_BUFFER_SIZE", CONFIG_ARDB_ROCKSDB_WRITE_BUFFER_SIZE,
                 DEFAULT_ARDB_ROCKSDB_WRITE_BUFFER_SIZE);
+    }
+
+    // Eureka
+    // ======
+
+    @Override
+    public boolean isEurekaHostsSupplierEnabled() {
+        return getBooleanProperty("DM_EUREKA_HOSTS_SUPPLIER_ENABLED", CONFIG_EUREKA_HOSTS_SUPPLIER_ENABLED,
+                DEFAULT_EUREKA_HOSTS_SUPPLIER_ENABLED);
     }
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -175,6 +175,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // =================
 
     private static final String CONFIG_REDIS_CONF = REDIS_PROPS + ".conf";
+    private static final String CONFIG_REDIS_DATA_DIR = REDIS_PROPS + ".data.dir";
     private static final String CONFIG_REDIS_PERSISTENCE_ENABLED = REDIS_PROPS + ".persistence.enabled";
     private static final String CONFIG_REDIS_START_SCRIPT = REDIS_PROPS + ".start.script";
     private static final String CONFIG_REDIS_STOP_SCRIPT = REDIS_PROPS + ".stop.script";
@@ -303,6 +304,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // ===========================
 
     private static final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
+    private static final String DEFAULT_REDIS_DATA_DIR = "/mnt/data/nfredis";
     private static final boolean DEFAULT_REDIS_PERSISTENCE_ENABLED = false;
     private static final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
     private static final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
@@ -823,6 +825,11 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     }
 
     @Override
+    public String getRedisDataDir() {
+        return getStringProperty("DM_REDIS_DATA_DIR", CONFIG_REDIS_DATA_DIR, DEFAULT_REDIS_DATA_DIR);
+    }
+
+    @Override
     public String getRedisStartScript() {
         return getStringProperty("DM_REDIS_START_SCRIPT", CONFIG_REDIS_START_SCRIPT, DEFAULT_REDIS_START_SCRIPT);
     }
@@ -836,13 +843,6 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     public boolean isRedisPersistenceEnabled() {
         return getBooleanProperty("DM_REDIS_PERSISTENCE_ENABLED", CONFIG_REDIS_PERSISTENCE_ENABLED,
                 DEFAULT_REDIS_PERSISTENCE_ENABLED);
-    }
-
-    @Override
-    public String getRedisDataDir() {
-        final String DEFAULT_REDIS_DATA_DIR = "/mnt/data/nfredis";
-        final String CONFIG_REDIS_DATA_DIR = DYNOMITEMANAGER_PRE + ".dyno.persistence.directory";
-        return configSource.get(CONFIG_REDIS_DATA_DIR, DEFAULT_REDIS_DATA_DIR);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -175,6 +175,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // =================
 
     private static final String CONFIG_REDIS_CONF = REDIS_PROPS + ".conf";
+    private static final String CONFIG_REDIS_PERSISTENCE_ENABLED = REDIS_PROPS + ".persistence.enabled";
     private static final String CONFIG_REDIS_START_SCRIPT = REDIS_PROPS + ".start.script";
     private static final String CONFIG_REDIS_STOP_SCRIPT = REDIS_PROPS + ".stop.script";
 
@@ -302,6 +303,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // ===========================
 
     private static final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
+    private static final boolean DEFAULT_REDIS_PERSISTENCE_ENABLED = false;
     private static final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
     private static final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
 
@@ -832,9 +834,8 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 
     @Override
     public boolean isRedisPersistenceEnabled() {
-        final boolean DEFAULT_REDIS_PERSISTENCE_ENABLED = false;
-        final String CONFIG_REDIS_PERSISTENCE_ENABLED = DYNOMITEMANAGER_PRE + ".dyno.persistence.enabled";
-        return configSource.get(CONFIG_REDIS_PERSISTENCE_ENABLED, DEFAULT_REDIS_PERSISTENCE_ENABLED);
+        return getBooleanProperty("DM_REDIS_PERSISTENCE_ENABLED", CONFIG_REDIS_PERSISTENCE_ENABLED,
+                DEFAULT_REDIS_PERSISTENCE_ENABLED);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -175,6 +175,8 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // =================
 
     private static final String CONFIG_REDIS_CONF = REDIS_PROPS + ".conf";
+    private static final String CONFIG_REDIS_START_SCRIPT = REDIS_PROPS + ".start.script";
+    private static final String CONFIG_REDIS_STOP_SCRIPT = REDIS_PROPS + ".stop.script";
 
     // Data store: ARDB with RocksDB
     // =============================
@@ -300,6 +302,8 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // ===========================
 
     private static final String DEFAULT_REDIS_CONF = "/apps/nfredis/conf/redis.conf";
+    private static final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
+    private static final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
 
     // Defaults: Data store: ARDB with RocksDB
     // =======================================
@@ -817,17 +821,13 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getRedisInitStart() {
-        final String DEFAULT_REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
-        final String CONFIG_REDIS_START_SCRIPT = DYNOMITEMANAGER_PRE + ".redis.init.start";
-        return configSource.get(CONFIG_REDIS_START_SCRIPT, DEFAULT_REDIS_START_SCRIPT);
+    public String getRedisStartScript() {
+        return getStringProperty("DM_REDIS_START_SCRIPT", CONFIG_REDIS_START_SCRIPT, DEFAULT_REDIS_START_SCRIPT);
     }
 
     @Override
-    public String getRedisInitStop() {
-        final String DEFAULT_REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
-        final String CONFIG_REDIS_STOP_SCRIPT = DYNOMITEMANAGER_PRE + ".redis.init.stop";
-        return configSource.get(CONFIG_REDIS_STOP_SCRIPT, DEFAULT_REDIS_STOP_SCRIPT);
+    public String getRedisStopScript() {
+        return getStringProperty("DM_REDIS_STOP_SCRIPT", CONFIG_REDIS_STOP_SCRIPT, DEFAULT_REDIS_STOP_SCRIPT);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/DynomiteManagerConfiguration.java
@@ -174,6 +174,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // Storage engine: ARDB with RocksDB
     // =================================
 
+    private static final String CONFIG_ARDB_ROCKSDB_CONF = ARDB_ROCKSDB_PROPS + ".conf";
     private static final String CONFIG_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER =
             ARDB_ROCKSDB_PROPS + ".max.write.buffer.number";
     private static final String CONFIG_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE =
@@ -290,6 +291,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
     // Defaults: Storage engine: ARDB with RocksDB
     // ===========================================
 
+    private static final String DEFAULT_ARDB_ROCKSDB_CONF = "/apps/ardb/conf/rocksdb.conf";
     private static final int DEFAULT_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER = 16;
     private static final int DEFAULT_ARDB_ROCKSDB_MIN_MEMTABLES_TO_MERGE = 4;
     private static final int DEFAULT_WRITE_BUFFER_SIZE_MB = 128;
@@ -857,9 +859,7 @@ public class DynomiteManagerConfiguration implements IConfiguration {
 
     @Override
     public String getArdbRocksDBConf() {
-        String DEFAULT_ARDB_ROCKSDB_CONF = "/apps/ardb/conf/rocksdb.conf";
-        final String CONFIG_ARDB_ROCKSDB_CONF = DYNOMITEMANAGER_PRE + ".ardb.rocksdb.conf";
-        return configSource.get(CONFIG_ARDB_ROCKSDB_CONF, DEFAULT_ARDB_ROCKSDB_CONF);
+        return getStringProperty("DM_ARDB_ROCKSDB_CONF", CONFIG_ARDB_ROCKSDB_CONF, DEFAULT_ARDB_ROCKSDB_CONF);
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -331,19 +331,18 @@ public interface IConfiguration {
     public String getRedisConf();
 
     /**
-     * Get the full path to the Redis init start script, including any
-     * arguments.
+     * Get the full path to the Redis init start script, including any arguments.
      *
      * @return the full path of the Redis init start script
      */
-    public String getRedisInitStart();
+    public String getRedisStartScript();
 
     /**
      * Get the full path to the Redis init stop script, including any arguments.
      *
      * @return the full path of the Redis init stop script
      */
-    public String getRedisInitStop();
+    public String getRedisStopScript();
 
     /**
      * Determines whether or not Redis will save data to disk.

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -387,20 +387,6 @@ public interface IConfiguration {
     public String getArdbRocksDBConf();
 
     /**
-     * Get the full path to the ARDB RocksDB init start script, including any arguments.
-     *
-     * @return the full path of the ARDB RocksDB init start script
-     */
-    public String getArdbRocksDBInitStart();
-
-    /**
-     * Get the full path to the ARDB RocksDB init stop script, including any arguments.
-     *
-     * @return the full path of the ARDB RocksDB init stop script
-     */
-    public String getArdbRocksDBInitStop();
-
-    /**
      * Get the maximum number of memtables used by RocksDB. This number includes both active and immutable memtables.
      *
      * @return the maximum number of memtables
@@ -413,6 +399,20 @@ public interface IConfiguration {
      * @return the minimum number of memtables that must exist before a flush occurs
      */
     public int getArdbRocksDBMinWriteBuffersToMerge();
+
+    /**
+     * Get the full path to the ARDB RocksDB init start script, including any arguments.
+     *
+     * @return the full path of the ARDB RocksDB init start script
+     */
+    public String getArdbRocksDBStartScript();
+
+    /**
+     * Get the full path to the ARDB RocksDB init stop script, including any arguments.
+     *
+     * @return the full path of the ARDB RocksDB init stop script
+     */
+    public String getArdbRocksDBStopScript();
 
     public int getWriteBufferSize();
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -235,16 +235,6 @@ public interface IConfiguration {
 
     public int getMaxTimeToBootstrap();
 
-    // Data store (aka backend)
-    // ========================
-
-    /**
-     * Get the maximum percentage of system memory to be allocated to the backend storage engine, such as Redis or ARDB.
-     *
-     * @return the max percentage of memory allocated to the storage engine
-     */
-    public int getDatastoreMaxMemoryPercent();
-
     // VPC
     public boolean isVpc();
 
@@ -319,8 +309,25 @@ public interface IConfiguration {
 
     public boolean isEurekaHostSupplierEnabled();
 
-    // Redis
-    // =====
+    // Data store (aka backend)
+    // ========================
+
+    /**
+     * Get the type of data store engine, such as Redis or ARDB with RocksDB.
+     *
+     * @return RESP backend data store server (redis, ardb-rocksdb)
+     */
+    public String getDatastoreEngine();
+
+    /**
+     * Get the maximum percentage of system memory to be allocated to the backend storage engine, such as Redis or ARDB.
+     *
+     * @return the max percentage of memory allocated to the storage engine
+     */
+    public int getDatastoreMaxMemoryPercent();
+
+    // Data store: Redis
+    // =================
 
     /**
      * Get the full path to the redis.conf configuration file.
@@ -372,13 +379,6 @@ public interface IConfiguration {
      * @return true if Redis should persist in-memory data to disk or false if Redis should only store data in-memory
      */
     public boolean isRedisPersistenceEnabled();
-
-    /**
-     * Get the type of Redis compatible (RESP) backend server.
-     *
-     * @return RESP backend server (redis, ardb-rocksdb)
-     */
-    public String getRedisCompatibleEngine();
 
     // Storage engine: ARDB with RocksDB
     // =================================

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -347,8 +347,7 @@ public interface IConfiguration {
     /**
      * Determines whether or not Redis will save data to disk.
      *
-     * @return true if Redis should persist in-memory data to disk or false if
-     *         Redis should only store data in-memory
+     * @return true if Redis should persist in-memory data to disk or false if Redis should only store data in-memory
      */
     public boolean isRedisPersistenceEnabled();
 

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -235,15 +235,15 @@ public interface IConfiguration {
 
     public int getMaxTimeToBootstrap();
 
-    // Storage engine (aka backend)
-    // ============================
+    // Data store (aka backend)
+    // ========================
 
     /**
      * Get the maximum percentage of system memory to be allocated to the backend storage engine, such as Redis or ARDB.
      *
      * @return the max percentage of memory allocated to the storage engine
      */
-    public int getStorageMaxMemoryPercent();
+    public int getDatastoreMaxMemoryPercent();
 
     // VPC
     public boolean isVpc();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -323,12 +323,27 @@ public interface IConfiguration {
     // =====
 
     /**
-     * Get the full path to the redis.conf configuration file. Netflix:
-     * /apps/nfredis/conf/redis.conf DynomiteDB: /etc/dynomitedb/redis.conf
+     * Get the full path to the redis.conf configuration file.
+     * Netflix: /apps/nfredis/conf/redis.conf
+     * DynomiteDB: /etc/dynomitedb/redis.conf
      *
      * @return the {@link String} full path to the redis.conf configuration file
      */
     public String getRedisConf();
+
+    /**
+     * Get the full path to the directory where Redis stores its AOF or RDB data files.
+     *
+     * @return the full path to the directory where Redis stores its data files
+     */
+    public String getRedisDataDir();
+
+    /**
+     * Get the persistence type of either AOF or RDB.
+     *
+     * @return the persistence type (aof, rdb)
+     */
+    public String getRedisPersistenceType();
 
     /**
      * Get the full path to the Redis init start script, including any arguments.
@@ -345,27 +360,18 @@ public interface IConfiguration {
     public String getRedisStopScript();
 
     /**
+     * Checks if Redis append-only file (AOF) persistence is enabled.
+     *
+     * @return true to indicate that AOF persistence is enabled or false to indicate that RDB persistence is enabled
+     */
+    public boolean isRedisAofEnabled();
+
+    /**
      * Determines whether or not Redis will save data to disk.
      *
      * @return true if Redis should persist in-memory data to disk or false if Redis should only store data in-memory
      */
     public boolean isRedisPersistenceEnabled();
-
-    /**
-     * Get the full path to the directory where Redis stores its AOF or RDB data
-     * files.
-     *
-     * @return the full path to the directory where Redis stores its data files
-     */
-    public String getRedisDataDir();
-
-    /**
-     * Checks if Redis append-only file (AOF) persistence is enabled.
-     *
-     * @return true to indicate that AOF persistence is enabled or false to
-     *         indicate that RDB persistence is enabled
-     */
-    public boolean isRedisAofEnabled();
 
     /**
      * Get the type of Redis compatible (RESP) backend server.

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -414,6 +414,11 @@ public interface IConfiguration {
      */
     public String getArdbRocksDBStopScript();
 
-    public int getWriteBufferSize();
+    /**
+     * Get the ARDB RocksDB write buffer size in MB.
+     *
+     * @return the RocksDB write buffer size in MB
+     */
+    public int getArdbRocksDBWriteBufferSize();
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/defaultimpl/IConfiguration.java
@@ -307,8 +307,6 @@ public interface IConfiguration {
      */
     public String getCassandraSeeds();
 
-    public boolean isEurekaHostSupplierEnabled();
-
     // Data store (aka backend)
     // ========================
 
@@ -380,8 +378,8 @@ public interface IConfiguration {
      */
     public boolean isRedisPersistenceEnabled();
 
-    // Storage engine: ARDB with RocksDB
-    // =================================
+    // Data store: ARDB with RocksDB
+    // =============================
 
     /**
      * Get the full path to the rocksdb.conf configuration file.
@@ -424,5 +422,10 @@ public interface IConfiguration {
      * @return the RocksDB write buffer size in MB
      */
     public int getArdbRocksDBWriteBufferSize();
+
+    // Eureka
+    // ======
+
+    public boolean isEurekaHostsSupplierEnabled();
 
 }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceDataDAOCassandra.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/identity/InstanceDataDAOCassandra.java
@@ -106,7 +106,7 @@ public class InstanceDataDAOCassandra {
 
 		this.hostSupplier = hostSupplier;
 
-		if (config.isEurekaHostSupplierEnabled())
+		if (config.isEurekaHostsSupplierEnabled())
 			ctx = initWithThriftDriverWithEurekaHostsSupplier();
 		else
 			ctx = initWithThriftDriverWithExternalHostsSupplier();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -547,7 +547,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
 	long storeMaxMem = getStoreMaxMem();
 
-        if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
+        if (config.getDatastoreEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             ArdbRocksDbRedisCompatible rocksDb = new ArdbRocksDbRedisCompatible(storeMaxMem,
                     config.getArdbRocksDBWriteBufferSize(), config.getArdbRocksDBMaxWriteBufferNumber(), config.getArdbRocksDBMinWriteBuffersToMerge());
             rocksDb.updateConfiguration(ArdbRocksDbRedisCompatible.DYNO_ARDB_CONF_PATH);
@@ -689,7 +689,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
     @Override
     public String getStartupScript() {
-        if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
+        if (config.getDatastoreEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return config.getArdbRocksDBStartScript();
         }
         return config.getRedisStartScript();
@@ -697,7 +697,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
     @Override
     public String getStopScript() {
-        if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
+        if (config.getDatastoreEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return config.getArdbRocksDBStopScript();
         }
         return config.getRedisStopScript();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -646,7 +646,7 @@ public class RedisStorageProxy implements IStorageProxy {
      * @return the maximum amount of storage available for Redis or Memcached in KB.
      */
     public long getStoreMaxMem() {
-	int memPct = config.getStorageMaxMemoryPercent();
+	int memPct = config.getDatastoreMaxMemoryPercent();
 	// Long is big enough for the amount of ram is all practical systems
 	// that we deal with.
 	long totalMem = getTotalAvailableSystemMemory();

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -692,7 +692,7 @@ public class RedisStorageProxy implements IStorageProxy {
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return config.getArdbRocksDBStartScript();
         }
-        return config.getRedisInitStart();
+        return config.getRedisStartScript();
     }
 
     @Override
@@ -700,7 +700,7 @@ public class RedisStorageProxy implements IStorageProxy {
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return config.getArdbRocksDBStopScript();
         }
-        return config.getRedisInitStop();
+        return config.getRedisStopScript();
     }
 
     @Override

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -690,7 +690,7 @@ public class RedisStorageProxy implements IStorageProxy {
     @Override
     public String getStartupScript() {
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
-            return config.getArdbRocksDBInitStart();
+            return config.getArdbRocksDBStartScript();
         }
         return config.getRedisInitStart();
     }
@@ -698,7 +698,7 @@ public class RedisStorageProxy implements IStorageProxy {
     @Override
     public String getStopScript() {
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
-            return config.getArdbRocksDBInitStop();
+            return config.getArdbRocksDBStopScript();
         }
         return config.getRedisInitStop();
     }

--- a/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
+++ b/dynomitemanager/src/main/java/com/netflix/dynomitemanager/sidecore/storage/RedisStorageProxy.java
@@ -549,7 +549,7 @@ public class RedisStorageProxy implements IStorageProxy {
 
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             ArdbRocksDbRedisCompatible rocksDb = new ArdbRocksDbRedisCompatible(storeMaxMem,
-                    config.getWriteBufferSize(), config.getArdbRocksDBMaxWriteBufferNumber(), config.getArdbRocksDBMinWriteBuffersToMerge());
+                    config.getArdbRocksDBWriteBufferSize(), config.getArdbRocksDBMaxWriteBufferNumber(), config.getArdbRocksDBMinWriteBuffersToMerge());
             rocksDb.updateConfiguration(ArdbRocksDbRedisCompatible.DYNO_ARDB_CONF_PATH);
         } else {
 	    // Updating the file.

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -214,6 +214,10 @@ dm.datastore.max.memory.percent=85
 # ENV: DM_REDIS_CONF
 dm.redis.conf=/apps/nfredis/conf/redis.conf
 
+# OLD: florida.dyno.persistence.directory
+# ENV: DM_REDIS_DATA_DIR
+dm.redis.data.dir=/mnt/data/nfredis
+
 # OLD: florida.dyno.persistence.enabled
 # ENV: DM_REDIS_PERSISTENCE_ENABLED
 dm.redis.persistence.enabled=false
@@ -225,10 +229,6 @@ dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh
 # OLD: florida.redis.init.stop
 # ENV: DM_REDIS_STOP_SCRIPT
 dm.redis.stop.script=/apps/nfredis/bin/kill_redis.sh
-
-# OLD: florida.
-# ENV: DM_REDIS_
-#dm.redis.
 
 # OLD: florida.
 # ENV: DM_REDIS_

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -203,8 +203,8 @@ dm.dynomite.write.consistency=DC_ONE
 # ENV: DM_DATASTORE_MAX_MEMORY_PERCENT
 dm.datastore.max.memory.percent=85
 
-# Storage engine: ARDB with RocksDB
-# =================================
+# Data store: ARDB with RocksDB
+# =============================
 
 # Maximum number of memtables (active and immutable) used by RocksDB.
 # OLD: florida.ardb.rocksdb.conf
@@ -228,9 +228,10 @@ dm.ardb.rocksdb.start.script=/apps/ardb/bin/launch_ardb.sh
 # ENV: DM_ARDB_ROCKSDB_STOP_SCRIPT
 dm.ardb.rocksdb.stop.script=/apps/ardb/bin/kill_ardb.sh
 
+# ARDB RocksDB write buffer size in MB.
 # OLD: florida.dyno.ardb.rocksdb.writebuffermb=128
-# ENV: DM_ARDB_ROCKSDB_WRITE_BUFFER_MB
-dm.ardb.rocksdb.write.buffer.mb=128
+# ENV: DM_ARDB_ROCKSDB_WRITE_BUFFER_SIZE
+dm.ardb.rocksdb.write.buffer.size=128
 
 # Additional configuration files / providers
 #@next=

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -198,14 +198,15 @@ dm.dynomite.write.consistency=DC_ONE
 # Data store (aka backend)
 # ============================
 
-# Max percentage of system memory to be allocated to the backend data store
+# Max percentage of system memory to be allocated to the backend data store.
 # OLD: florida.dyno.storage.mem.pct.int=85
 # ENV: DM_DATASTORE_MAX_MEMORY_PERCENT
 dm.datastore.max.memory.percent=85
 
-# OLD: florida.
+# Backend data store server engine: redis or ardb-rocksdb.
+# OLD: florida.dyno.redis.compatible.engine
 # ENV: DM_DATASTORE_ENGINE
-#dm.datastore.engine=redis
+dm.datastore.engine=redis
 
 # Data store: Redis
 # =================
@@ -233,10 +234,6 @@ dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh
 # OLD: florida.redis.init.stop
 # ENV: DM_REDIS_STOP_SCRIPT
 dm.redis.stop.script=/apps/nfredis/bin/kill_redis.sh
-
-# OLD: florida.
-# ENV: DM_REDIS_
-#dm.redis.
 
 # Data store: ARDB with RocksDB
 # =============================

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -214,6 +214,10 @@ dm.datastore.max.memory.percent=85
 # ENV: DM_REDIS_CONF
 dm.redis.conf=/apps/nfredis/conf/redis.conf
 
+# OLD: florida.dyno.persistence.enabled
+# ENV: DM_REDIS_PERSISTENCE_ENABLED
+dm.redis.persistence.enabled=false
+
 # OLD: florida.redis.init.start
 # ENV: DM_REDIS_START_SCRIPT
 dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh
@@ -221,10 +225,6 @@ dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh
 # OLD: florida.redis.init.stop
 # ENV: DM_REDIS_STOP_SCRIPT
 dm.redis.stop.script=/apps/nfredis/bin/kill_redis.sh
-
-# OLD: florida.
-# ENV: DM_REDIS_
-#dm.redis.
 
 # OLD: florida.
 # ENV: DM_REDIS_

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -207,6 +207,11 @@ dm.datastore.max.memory.percent=85
 # =================================
 
 # Maximum number of memtables (active and immutable) used by RocksDB.
+# OLD: florida.ardb.rocksdb.conf
+# ENV: DM_ARDB_ROCKSDB_CONF
+dm.ardb.rocksdb.conf=/apps/ardb/conf/rocksdb.conf
+
+# Maximum number of memtables (active and immutable) used by RocksDB.
 # OLD: florida.dyno.ardb.rocksdb.maxwritebuffernumber=16
 # ENV: DM_ARDB_ROCKSDB_MAX_WRITE_BUFFER_NUMBER
 dm.ardb.rocksdb.max.write.buffer.number=16

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -200,8 +200,8 @@ dm.dynomite.write.consistency=DC_ONE
 
 # Max percentage of system memory to be allocated to the backend data store
 # OLD: florida.dyno.storage.mem.pct.int=85
-# ENV: DM_STORAGE_MAX_MEMORY_PERCENT
-dm.storage.max.memory.percent=85
+# ENV: DM_DATASTORE_MAX_MEMORY_PERCENT
+dm.datastore.max.memory.percent=85
 
 # Storage engine: ARDB with RocksDB
 # =================================

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -220,6 +220,14 @@ dm.ardb.rocksdb.max.write.buffer.number=16
 # ENV: DM_ARDB_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE
 dm.ardb.rocksdb.min.write.buffer.number.to.merge=4
 
+# OLD: florida.ardb.rocksdb.init.start
+# ENV: DM_ARDB_ROCKSDB_START_SCRIPT
+dm.ardb.rocksdb.start.script=/apps/ardb/bin/launch_ardb.sh
+
+# OLD: florida.ardb.rocksdb.init.stop
+# ENV: DM_ARDB_ROCKSDB_STOP_SCRIPT
+dm.ardb.rocksdb.stop.script=/apps/ardb/bin/kill_ardb.sh
+
 # OLD: florida.dyno.ardb.rocksdb.writebuffermb=128
 # ENV: DM_ARDB_ROCKSDB_WRITE_BUFFER_MB
 dm.ardb.rocksdb.write.buffer.mb=128

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -222,6 +222,10 @@ dm.redis.data.dir=/mnt/data/nfredis
 # ENV: DM_REDIS_PERSISTENCE_ENABLED
 dm.redis.persistence.enabled=false
 
+# OLD: florida.dyno.persistence.type
+# ENV: DM_REDIS_PERSISTENCE_TYPE
+dm.redis.persistence.type=aof
+
 # OLD: florida.redis.init.start
 # ENV: DM_REDIS_START_SCRIPT
 dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -214,13 +214,13 @@ dm.datastore.max.memory.percent=85
 # ENV: DM_REDIS_CONF
 dm.redis.conf=/apps/nfredis/conf/redis.conf
 
-# OLD: florida.
-# ENV: DM_REDIS_
-#dm.redis.
+# OLD: florida.redis.init.start
+# ENV: DM_REDIS_START_SCRIPT
+dm.redis.start.script=/apps/nfredis/bin/launch_nfredis.sh
 
-# OLD: florida.
-# ENV: DM_REDIS_
-#dm.redis.
+# OLD: florida.redis.init.stop
+# ENV: DM_REDIS_STOP_SCRIPT
+dm.redis.stop.script=/apps/nfredis/bin/kill_redis.sh
 
 # OLD: florida.
 # ENV: DM_REDIS_

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -139,10 +139,6 @@ dm.cassandra.thrift.port=9160
 # DM_CASSANDRA_SEEDS
 dm.cassandra.seeds=127.0.0.1
 
-# Eureka
-# ======
-#florida.eureka.host.supplier.enabled=true
-
 # Amazon specific
 # ===============
 #florida.az.asgname=UNUSED-CONFIGURATION-OPTION
@@ -264,6 +260,13 @@ dm.ardb.rocksdb.stop.script=/apps/ardb/bin/kill_ardb.sh
 # OLD: florida.dyno.ardb.rocksdb.writebuffermb=128
 # ENV: DM_ARDB_ROCKSDB_WRITE_BUFFER_SIZE
 dm.ardb.rocksdb.write.buffer.size=128
+
+# Eureka
+# ======
+
+# OLD: florida.eureka.host.supplier.enabled=true
+# ENV: DM_EUREKA_HOSTS_SUPPLIER_ENABLED
+dm.eureka.hosts.supplier.enabled=true
 
 # Additional configuration files / providers
 #@next=

--- a/dynomitemanager/src/main/resources/dynomitemanager.properties
+++ b/dynomitemanager/src/main/resources/dynomitemanager.properties
@@ -195,13 +195,44 @@ dm.dynomite.write.consistency=DC_ONE
 # VPC
 #florida.instanceDataRetriever=com.netflix.dynomitemanager.sidecore.config.VpcInstanceDataRetriever
 
-# Storage engine (aka backend)
+# Data store (aka backend)
 # ============================
 
 # Max percentage of system memory to be allocated to the backend data store
 # OLD: florida.dyno.storage.mem.pct.int=85
 # ENV: DM_DATASTORE_MAX_MEMORY_PERCENT
 dm.datastore.max.memory.percent=85
+
+# OLD: florida.
+# ENV: DM_DATASTORE_ENGINE
+#dm.datastore.engine=redis
+
+# Data store: Redis
+# =================
+
+# OLD: florida.redis.conf
+# ENV: DM_REDIS_CONF
+dm.redis.conf=/apps/nfredis/conf/redis.conf
+
+# OLD: florida.
+# ENV: DM_REDIS_
+#dm.redis.
+
+# OLD: florida.
+# ENV: DM_REDIS_
+#dm.redis.
+
+# OLD: florida.
+# ENV: DM_REDIS_
+#dm.redis.
+
+# OLD: florida.
+# ENV: DM_REDIS_
+#dm.redis.
+
+# OLD: florida.
+# ENV: DM_REDIS_
+#dm.redis.
 
 # Data store: ARDB with RocksDB
 # =============================

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -336,12 +336,12 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getRedisInitStart() {
+    public String getRedisStartScript() {
 	return null;
     }
 
     @Override
-    public String getRedisInitStop() {
+    public String getRedisStopScript() {
 	return null;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -52,7 +52,7 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public boolean isEurekaHostSupplierEnabled() {
+    public boolean isEurekaHostsSupplierEnabled() {
 	return false;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -96,7 +96,7 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getStorageMaxMemoryPercent() {
+    public int getDatastoreMaxMemoryPercent() {
 	return 0;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -331,7 +331,7 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getRedisCompatibleEngine() {
+    public String getDatastoreEngine() {
 	return null;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -364,7 +364,7 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public int getWriteBufferSize() {
+    public int getArdbRocksDBWriteBufferSize() {
 	return 0;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -42,6 +42,11 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
+    public String getRedisPersistenceType() {
+        return null;
+    }
+
+    @Override
     public boolean isDynomiteMultiDC() {
 	return false;
     }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/BlankConfiguration.java
@@ -354,12 +354,12 @@ public class BlankConfiguration implements IConfiguration {
     }
 
     @Override
-    public String getArdbRocksDBInitStart() {
+    public String getArdbRocksDBStartScript() {
 	return null;
     }
 
     @Override
-    public String getArdbRocksDBInitStop() {
+    public String getArdbRocksDBStopScript() {
 	return null;
     }
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -626,6 +626,26 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("Redis stop script = default", conf.getRedisStopScript(), is("/apps/nfredis/bin/kill_redis.sh"));
     }
 
+    @Test
+    public void testIsRedisPersistenceEnabled() throws Exception {
+        Assert.assertThat("Redis persistence = default", conf.isRedisPersistenceEnabled(), is(false));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "true";
+            }
+        };
+        Assert.assertThat("Redis persistence = env var", conf.isRedisPersistenceEnabled(), is(true));
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Redis persistence = default", conf.isRedisPersistenceEnabled(), is(false));
+    }
+
     // Data store: ARDB with RocksDB
     // =============================
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -539,6 +539,27 @@ public class DynomiteManagerConfigurationTest {
     // ========================
 
     @Test
+    public void testGetDatastoreEngine() throws Exception {
+        Assert.assertThat("Data store engine = default", conf.getDatastoreEngine(), is("redis"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "ardb-rocksdb";
+            }
+        };
+        Assert.assertThat("Data store engine = env var", conf.getDatastoreEngine(), is("ardb-rocksdb"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Data store engine = default", conf.getDatastoreEngine(), is("redis"));
+    }
+
+    @Test
     public void testGetDatastoreMaxMemoryPercent() throws Exception {
         Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -848,4 +848,27 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("ARDB RocksDB write buffer size in MB = default", conf.getArdbRocksDBWriteBufferSize(), is(128));
     }
 
+    // Eureka
+    // ======
+
+    @Test
+    public void testIsEurekaHostsSupplierEnabled() throws Exception {
+        Assert.assertThat("Eureka hosts supplier = default", conf.isEurekaHostsSupplierEnabled(), is(true));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "false";
+            }
+        };
+        Assert.assertThat("Eureka hosts supplier = env var", conf.isEurekaHostsSupplierEnabled(), is(false));
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Eureka hosts supplier = default", conf.isEurekaHostsSupplierEnabled(), is(true));
+    }
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -584,6 +584,48 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("Redis conf = default", conf.getRedisConf(), is("/apps/nfredis/conf/redis.conf"));
     }
 
+    @Test
+    public void testGetRedisStartScript() throws Exception {
+        Assert.assertThat("Redis start script = default", conf.getRedisStartScript(), is("/apps/nfredis/bin/launch_nfredis.sh"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/init.d/redis";
+            }
+        };
+        Assert.assertThat("Redis start script = env var", conf.getRedisStartScript(), is("/etc/init.d/redis"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Redis start script = default", conf.getRedisStartScript(), is("/apps/nfredis/bin/launch_nfredis.sh"));
+    }
+
+    @Test
+    public void testGetRedisStopScript() throws Exception {
+        Assert.assertThat("Redis stop script = default", conf.getRedisStopScript(), is("/apps/nfredis/bin/kill_redis.sh"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/init.d/redis";
+            }
+        };
+        Assert.assertThat("Redis stop script = env var", conf.getRedisStopScript(), is("/etc/init.d/redis"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Redis stop script = default", conf.getRedisStopScript(), is("/apps/nfredis/bin/kill_redis.sh"));
+    }
+
     // Data store: ARDB with RocksDB
     // =============================
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -537,11 +537,11 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("Cassandra thrift port = default", conf.getCassandraThriftPort(), is(9160));
     }
 
-    // Storage engine (aka backend)
-    // ============================
+    // Data store (aka backend)
+    // ========================
 
     @Test
-    public void testGetStorageMaxMemoryPercent() throws Exception {
+    public void testGetDatastoreMaxMemoryPercent() throws Exception {
         Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
 
         new MockUp<System>() {
@@ -560,8 +560,8 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
     }
 
-    // Storage engine: ARDB with RocksDB
-    // =================================
+    // Data store: ARDB with RocksDB
+    // =============================
 
     @Test
     public void testGetArdbRocksDBConf() throws Exception {
@@ -664,6 +664,27 @@ public class DynomiteManagerConfigurationTest {
             }
         };
         Assert.assertThat("ARDB RocksDB stop script = default", conf.getArdbRocksDBStopScript(), is("/apps/ardb/bin/kill_ardb.sh"));
+    }
+
+    @Test
+    public void testGetArdbRocksDBWriteBufferSize() throws Exception {
+        Assert.assertThat("ARDB RocksDB write buffer size in MB = default", conf.getArdbRocksDBWriteBufferSize(), is(128));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "256";
+            }
+        };
+        Assert.assertThat("ARDB RocksDB write buffer size in MB = env var", conf.getArdbRocksDBWriteBufferSize(), is(256));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "not-a-number";
+            }
+        };
+        Assert.assertThat("ARDB RocksDB write buffer size in MB = default", conf.getArdbRocksDBWriteBufferSize(), is(128));
     }
 
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -560,6 +560,30 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
     }
 
+    // Data store: Redis
+    // =================
+
+    @Test
+    public void testGetRedisConf() throws Exception {
+        Assert.assertThat("Redis conf = default", conf.getRedisConf(), is("/apps/nfredis/conf/redis.conf"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/redis/redis.conf";
+            }
+        };
+        Assert.assertThat("Redis conf = env var", conf.getRedisConf(), is("/etc/redis/redis.conf"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Redis conf = default", conf.getRedisConf(), is("/apps/nfredis/conf/redis.conf"));
+    }
+
     // Data store: ARDB with RocksDB
     // =============================
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -585,6 +585,27 @@ public class DynomiteManagerConfigurationTest {
     }
 
     @Test
+    public void testGetRedisDataDir() throws Exception {
+        Assert.assertThat("Redis data dir = default", conf.getRedisDataDir(), is("/mnt/data/nfredis"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/usr/share/redis";
+            }
+        };
+        Assert.assertThat("Redis data dir = env var", conf.getRedisDataDir(), is("/usr/share/redis"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("Redis data dir = default", conf.getRedisDataDir(), is("/mnt/data/nfredis"));
+    }
+
+    @Test
     public void testGetRedisStartScript() throws Exception {
         Assert.assertThat("Redis start script = default", conf.getRedisStartScript(), is("/apps/nfredis/bin/launch_nfredis.sh"));
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -564,6 +564,27 @@ public class DynomiteManagerConfigurationTest {
     // =================================
 
     @Test
+    public void testGetArdbRocksDBConf() throws Exception {
+        Assert.assertThat("ARDB RocksDB conf = default", conf.getArdbRocksDBConf(), is("/apps/ardb/conf/rocksdb.conf"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/ardb/rocksdb.conf";
+            }
+        };
+        Assert.assertThat("ARDB RocksDB conf = env var", conf.getArdbRocksDBConf(), is("/etc/ardb/rocksdb.conf"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("ARDB RocksDB conf = default", conf.getArdbRocksDBConf(), is("/apps/ardb/conf/rocksdb.conf"));
+    }
+
+    @Test
     public void testGetArdbRocksDBMaxWriteBufferNumber() throws Exception {
         Assert.assertThat("ARDB RocksDB max write buffer number = default", conf.getArdbRocksDBMaxWriteBufferNumber(), is(16));
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -624,4 +624,46 @@ public class DynomiteManagerConfigurationTest {
         Assert.assertThat("ARDB RocksDB min memtables before flush = default", conf.getArdbRocksDBMinWriteBuffersToMerge(), is(4));
     }
 
+    @Test
+    public void testGetArdbRocksDBStartScript() throws Exception {
+        Assert.assertThat("ARDB RocksDB start script = default", conf.getArdbRocksDBStartScript(), is("/apps/ardb/bin/launch_ardb.sh"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/init.d/ardb";
+            }
+        };
+        Assert.assertThat("ARDB RocksDB start script = env var", conf.getArdbRocksDBStartScript(), is("/etc/init.d/ardb"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("ARDB RocksDB start script = default", conf.getArdbRocksDBStartScript(), is("/apps/ardb/bin/launch_ardb.sh"));
+    }
+
+    @Test
+    public void testGetArdbRocksDBStopScript() throws Exception {
+        Assert.assertThat("ARDB RocksDB stop script = default", conf.getArdbRocksDBStopScript(), is("/apps/ardb/bin/kill_ardb.sh"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return "/etc/init.d/ardb";
+            }
+        };
+        Assert.assertThat("ARDB RocksDB stop script = env var", conf.getArdbRocksDBStopScript(), is("/etc/init.d/ardb"));
+
+        new MockUp<System>() {
+            @Mock
+            String getenv(String name) {
+                return null;
+            }
+        };
+        Assert.assertThat("ARDB RocksDB stop script = default", conf.getArdbRocksDBStopScript(), is("/apps/ardb/bin/kill_ardb.sh"));
+    }
+
 }

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/defaultimpl/test/DynomiteManagerConfigurationTest.java
@@ -542,7 +542,7 @@ public class DynomiteManagerConfigurationTest {
 
     @Test
     public void testGetStorageMaxMemoryPercent() throws Exception {
-        Assert.assertThat("storage max memory percent = default", conf.getStorageMaxMemoryPercent(), is(85));
+        Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
 
         new MockUp<System>() {
             @Mock
@@ -550,14 +550,14 @@ public class DynomiteManagerConfigurationTest {
                 return "70";
             }
         };
-        Assert.assertThat("storage max memory percent = env var", conf.getStorageMaxMemoryPercent(), is(70));
+        Assert.assertThat("storage max memory percent = env var", conf.getDatastoreMaxMemoryPercent(), is(70));
         new MockUp<System>() {
             @Mock
             String getenv(String name) {
                 return "not-a-number";
             }
         };
-        Assert.assertThat("storage max memory percent = default", conf.getStorageMaxMemoryPercent(), is(85));
+        Assert.assertThat("storage max memory percent = default", conf.getDatastoreMaxMemoryPercent(), is(85));
     }
 
     // Storage engine: ARDB with RocksDB

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -338,12 +338,12 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRedisInitStart() {
+	public String getRedisStartScript() {
 		return null;
 	}
 
 	@Override
-	public String getRedisInitStop() {
+	public String getRedisStopScript() {
 		return null;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -356,12 +356,12 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getArdbRocksDBInitStart() {
+	public String getArdbRocksDBStartScript() {
 		return null;
 	}
 
 	@Override
-	public String getArdbRocksDBInitStop() {
+	public String getArdbRocksDBStopScript() {
 		return null;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -96,7 +96,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public int getStorageMaxMemoryPercent() {
+	public int getDatastoreMaxMemoryPercent() {
 		return 0;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -41,7 +41,12 @@ public class SimpleTestConfiguration implements IConfiguration {
 		return false;
 	}
 
-	@Override
+    @Override
+    public String getRedisPersistenceType() {
+        return null;
+    }
+
+    @Override
 	public boolean isDynomiteMultiDC() {
 		return false;
 	}

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -52,7 +52,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public boolean isEurekaHostSupplierEnabled() {
+	public boolean isEurekaHostsSupplierEnabled() {
 		return false;
 	}
 

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -332,7 +332,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public String getRedisCompatibleEngine() {
+	public String getDatastoreEngine() {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
+++ b/dynomitemanager/src/test/java/com/netflix/dynomitemanager/identity/test/SimpleTestConfiguration.java
@@ -366,7 +366,7 @@ public class SimpleTestConfiguration implements IConfiguration {
 	}
 
 	@Override
-	public int getWriteBufferSize() {
+	public int getArdbRocksDBWriteBufferSize() {
 	    return 0;
 	}
 


### PR DESCRIPTION
Most of the FP are now updated to use Archaius, with the only major exception being the AWS specific FP...which I'm working on currently. 

I also updated the FP name for `datastore` to match @shailesh33 suggestion from https://github.com/Netflix/dynomite/issues/368.