### PR TITLE
FORCE right CONTEXT_ROOT for DM app using jetty

### DIFF
--- a/dynomitemanager-web/build.gradle
+++ b/dynomitemanager-web/build.gradle
@@ -7,3 +7,6 @@ apply plugin: 'war'
 dependencies {
     compile project(':dynomitemanager')
 }
+
+jettyRun.contextPath = ''
+jettyRunWar.contextPath = ''


### PR DESCRIPTION
@ipapapa 

By default when we run DM app using $ ./gradlew jettyRun or $ ./gradlew jettyRunWar.

Jetty sets the CONTEXT_ROOT to the name of the eclipse project which is dynomitemanager-web and this will make dynomtie to not work correctly since dynomtie needs to access this endpoint: http://127.0.0.1:8080/REST/v1/admin/get_seeds and DM would be published on http://127.0.0.1:8080/dynomitemanager-web/REST/v1/admin/get_seeds

This is a little bit hard to get since Dynomite will boot up properly but only appears when the seeds change in case an ASG replace an instance(let's say an AZ/ASG gets Down) you will realize dynomtie is no properly polling DM. 

As It is this is part 1 in order to FIX https://github.com/Netflix/dynomite-manager/issues/72

This PR is to FIX this issue for OSS users that run DM with Jetty like me :smile: 

Cheers,
Diego Pacheco