### PR TITLE
Centralizing FPs, Removing static calls, Connection leak

### DIFF
--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/config/FloridaConfig.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/config/FloridaConfig.java
@@ -67,6 +67,13 @@ public interface FloridaConfig {
     @DefaultValue("florida_provider")
     @PropertyName(name = "dyno.seed.provider")
     public String getDynomiteSeedProvider();
+    
+    /**
+     * @return Get the stats port
+     */
+    @DefaultValue("http://localhost:22222")
+    @PropertyName(name = "metrics.url")
+    public String getAdminUrl();   
 
     /**
      * Get the Dynomite process name.

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteRest.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteRest.java
@@ -7,19 +7,24 @@ import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netflix.config.DynamicPropertyFactory;
-import com.netflix.config.DynamicStringProperty;
+import com.google.inject.Inject;
+import com.netflix.dynomitemanager.config.FloridaConfig;
 
 public class DynomiteRest {
     
     private static final Logger logger = LoggerFactory.getLogger(DynomiteRest.class);
 
+    private FloridaConfig config;
     
-    public static boolean sendCommand(String cmd) {
-    	DynamicStringProperty adminUrl = 
-                DynamicPropertyFactory.getInstance().getStringProperty("florida.metrics.url", "http://localhost:22222");
-    	
-        String url = adminUrl.get() + cmd;
+    @Inject
+    public DynomiteRest(FloridaConfig config) {
+    	this.config = config;
+    }
+
+    
+    public boolean sendCommand(String cmd) {
+    	    	    			
+        String url = config.getAdminUrl() + cmd;
         HttpClient client = new HttpClient();
         client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, 
                                         new DefaultHttpMethodRetryHandler());

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteStandardTuner.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/DynomiteStandardTuner.java
@@ -57,7 +57,7 @@ public class DynomiteStandardTuner implements ProcessTuner {
      * allocation is based on the instancy type 2GB for Florida + 85% for Redis
      */
 
-    public int setMaxMsgs() {
+    private int setMaxMsgs() {
         if (floridaConfig.getDynomiteMaxAllocatedMessages() == 0) {
 
             String instanceType = this.instanceDataRetriever.getInstanceType();

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/ProxyAndStorageResetTask.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/dynomite/ProxyAndStorageResetTask.java
@@ -24,14 +24,16 @@ public class ProxyAndStorageResetTask extends Task {
     private final StorageProxy storageProxy;
     private final Sleeper sleeper;
     private final FloridaConfig config;
+    private final DynomiteRest dynoRest;
 
     @Inject
     public ProxyAndStorageResetTask(FloridaConfig config, IDynomiteProcess dynProcess, StorageProxy storageProxy,
-            Sleeper sleeper) {
+            Sleeper sleeper, DynomiteRest dynoRest) {
         this.config = config;
         this.storageProxy = storageProxy;
         this.dynProcess = dynProcess;
         this.sleeper = sleeper;
+        this.dynoRest = dynoRest;
     }
 
     public void execute() throws IOException {
@@ -47,10 +49,10 @@ public class ProxyAndStorageResetTask extends Task {
 
     private void setConsistency() {
         logger.info("Setting the consistency level for the cluster");
-        if (!DynomiteRest.sendCommand("/set_consistency/read/" + config.getDynomiteReadConsistency()))
+        if (!dynoRest.sendCommand("/set_consistency/read/" + config.getDynomiteReadConsistency()))
             logger.error("REST call to Dynomite for read consistency failed --> using the default");
 
-        if (!DynomiteRest.sendCommand("/set_consistency/write/" + config.getDynomiteWriteConsistency()))
+        if (!dynoRest.sendCommand("/set_consistency/write/" + config.getDynomiteWriteConsistency()))
             logger.error("REST call to Dynomite for write consistency failed --> using the default");
     }
 
@@ -85,6 +87,8 @@ public class ProxyAndStorageResetTask extends Task {
             } catch (IOException e1) {
                 logger.error("Dynomite cannot be restarted --> Requires manual restart" + e1.getMessage());
             }
+        } finally {
+        	dynomiteJedis.close();
         }
 
     }


### PR DESCRIPTION
* `FloridaMetricsUrl` was an FP that was not handled centrally by the `FloridaConfig`.
* In `dynomiteCheck` we were probably leaking connections. 