### PR TITLE
Parameterize redis config

### DIFF
--- a/dynomitemanager-common/src/main/java/com/netflix/nfsidecar/config/RedisConfig.java
+++ b/dynomitemanager-common/src/main/java/com/netflix/nfsidecar/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.netflix.nfsidecar.config;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
+
+@Configuration(prefix = "redis")
+public interface RedisConfig {
+    @DefaultValue("/apps/nfredis/conf/redis.conf")
+    @PropertyName(name = "confPath")
+    String getConfPath();
+
+    @DefaultValue("127.0.0.1")
+    @PropertyName(name = "address")
+    String getAddress();
+
+    @DefaultValue("22122")
+    @PropertyName(name = "port")
+    int getPort();
+
+    @DefaultValue("/apps/nfredis/bin/launch_nfredis.sh")
+    @PropertyName(name = "startScript")
+    String getStartScript();
+
+    @DefaultValue("/apps/nfredis/bin/kill_redis.sh")
+    @PropertyName(name = "stopScript")
+    String getStopScript();
+}

--- a/dynomitemanager-common/src/main/java/com/netflix/nfsidecar/config/RedisConfig.java
+++ b/dynomitemanager-common/src/main/java/com/netflix/nfsidecar/config/RedisConfig.java
@@ -18,6 +18,10 @@ public interface RedisConfig {
     @PropertyName(name = "port")
     int getPort();
 
+    @DefaultValue("true")
+    @PropertyName(name = "daemonize")
+    boolean shouldDaemonize();
+
     @DefaultValue("/apps/nfredis/bin/launch_nfredis.sh")
     @PropertyName(name = "startScript")
     String getStartScript();

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
@@ -5,6 +5,7 @@ import com.google.common.base.Splitter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.dynomitemanager.config.FloridaConfig;
+import com.netflix.nfsidecar.config.RedisConfig;
 import com.netflix.nfsidecar.scheduler.SimpleTimer;
 import com.netflix.nfsidecar.scheduler.Task;
 import com.netflix.nfsidecar.scheduler.TaskTimer;
@@ -43,15 +44,9 @@ import java.util.regex.Pattern;
 public class RedisStorageProxy extends Task implements StorageProxy, HealthIndicator {
 
     private static final String DYNO_REDIS = "redis";
-    private static final String DYNO_REDIS_CONF_PATH = "/apps/nfredis/conf/redis.conf";
-    private static final String REDIS_ADDRESS = "127.0.0.1";
-    private static final int REDIS_PORT = 22122;
     private static final long GB_2_IN_KB = 2L * 1024L * 1024L;
     private static final String PROC_MEMINFO_PATH = "/proc/meminfo";
     private static final Pattern MEMINFO_PATTERN = Pattern.compile("MemTotal:\\s*([0-9]*)");
-
-    private final String REDIS_START_SCRIPT = "/apps/nfredis/bin/launch_nfredis.sh";
-    private final String REDIS_STOP_SCRIPT = "/apps/nfredis/bin/kill_redis.sh";
 
     private static final String REDIS_CONF_MAXMEMORY_PATTERN = "^maxmemory\\s*[0-9][0-9]*[a-zA-Z]*";
     private static final String REDIS_CONF_APPENDONLY = "^appendonly\\s*[a-zA-Z]*";
@@ -71,13 +66,15 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
     private boolean redisHealth = false;
 
     private final FloridaConfig config;
+    private final RedisConfig redisConfig;
 
     @Inject
     private Sleeper sleeper;
 
     @Inject
-    public RedisStorageProxy(FloridaConfig config) {
+    public RedisStorageProxy(FloridaConfig config, RedisConfig redisConfig) {
         this.config = config;
+        this.redisConfig = redisConfig;
         // connect();
     }
 
@@ -101,7 +98,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
     private void localRedisConnect() {
         if (this.localJedis == null) {
             logger.info("Connecting to Redis.");
-            this.localJedis = JedisUtils.connect(REDIS_ADDRESS, REDIS_PORT);
+            this.localJedis = JedisUtils.connect(this.redisConfig.getAddress(), this.redisConfig.getPort());
         }
     }
 
@@ -315,7 +312,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
     public boolean isAlive() {
         // Not using localJedis variable as it can be used by
         // ProcessMonitorTask as well.
-        return JedisUtils.isAliveWithRetry(REDIS_ADDRESS, REDIS_PORT);
+        return JedisUtils.isAliveWithRetry(this.redisConfig.getAddress(), this.redisConfig.getPort());
     }
 
     public long getUptime() {
@@ -371,7 +368,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
         for (String peer : peers) { // Looking into the peers with the same
                                     // token
             logger.info("Peer node [" + peer + "] has the same token!");
-            peerJedis = JedisUtils.connect(peer, REDIS_PORT);
+            peerJedis = JedisUtils.connect(peer, this.redisConfig.getPort());
             if (peerJedis != null && isAlive()) { // Checking if there are
                                                   // peers, and if so if they
                                                   // are alive
@@ -400,8 +397,8 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
             String alivePeer = longestAlivePeer.selectedPeer;
             peerJedis = longestAlivePeer.selectedJedis;
 
-            logger.info("Issue slaveof command on peer [" + alivePeer + "] and port [" + REDIS_PORT + "]");
-            startPeerSync(alivePeer, REDIS_PORT);
+            logger.info("Issue slaveof command on peer [" + alivePeer + "] and port [" + this.redisConfig.getPort() + "]");
+            startPeerSync(alivePeer, this.redisConfig.getPort());
 
             long diff = 0;
             long previousDiff = 0;
@@ -606,9 +603,9 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
         } else {
 
             // Updating the file.
-            logger.info("Updating Redis conf: " + DYNO_REDIS_CONF_PATH);
-            Path confPath = Paths.get(DYNO_REDIS_CONF_PATH);
-            Path backupPath = Paths.get(DYNO_REDIS_CONF_PATH + ".bkp");
+            logger.info("Updating Redis conf: " + this.redisConfig.getConfPath());
+            Path confPath = Paths.get(this.redisConfig.getConfPath());
+            Path backupPath = Paths.get(this.redisConfig.getConfPath() + ".bkp");
 
             // backup the original baked in conf only and not subsequent updates
             if (!Files.exists(backupPath)) {
@@ -792,7 +789,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_START_SCRIPT;
         }
-        return REDIS_START_SCRIPT;
+        return this.redisConfig.getStartScript();
     }
 
     @Override
@@ -800,17 +797,17 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
         if (config.getRedisCompatibleEngine().equals(ArdbRocksDbRedisCompatible.DYNO_ARDB)) {
             return ArdbRocksDbRedisCompatible.ARDB_ROCKSDB_STOP_SCRIPT;
         }
-        return REDIS_STOP_SCRIPT;
+        return this.redisConfig.getStopScript();
     }
 
     @Override
     public String getIpAddress() {
-        return REDIS_ADDRESS;
+        return this.redisConfig.getAddress();
     }
 
     @Override
     public int getPort() {
-        return REDIS_PORT;
+        return this.redisConfig.getPort();
     }
 
     @Override

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
@@ -669,7 +669,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
                     lines.set(i, maxMemConf);
                 }
                 if (line.matches(REDIS_CONF_DAEMONIZE)) {
-                    String daemonize = "daemonize yes";
+                    String daemonize = String.format("daemonize %s", redisConfig.shouldDaemonize() ? "yes" : "no");
                     logger.info("Updating Redis property: " + daemonize);
                     lines.set(i, daemonize);
                 }

--- a/dynomitemanager-web/src/main/java/com/netflix/florida/startup/FloridaModule.java
+++ b/dynomitemanager-web/src/main/java/com/netflix/florida/startup/FloridaModule.java
@@ -13,7 +13,6 @@
 package com.netflix.florida.startup;
 
 import com.google.inject.AbstractModule;
-// Common module dependencies
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 import com.netflix.archaius.ConfigProxyFactory;
@@ -31,12 +30,6 @@ import com.netflix.dynomitemanager.monitoring.JedisFactory;
 import com.netflix.dynomitemanager.monitoring.SimpleJedisFactory;
 import com.netflix.dynomitemanager.storage.RedisStorageProxy;
 import com.netflix.dynomitemanager.storage.StorageProxy;
-
-import javax.inject.Singleton;
-
-import org.quartz.SchedulerFactory;
-import org.quartz.impl.StdSchedulerFactory;
-
 import com.netflix.nfsidecar.aws.AWSMembership;
 import com.netflix.nfsidecar.aws.AwsInstanceEnvIdentity;
 import com.netflix.nfsidecar.aws.IAMCredential;
@@ -46,12 +39,12 @@ import com.netflix.nfsidecar.backup.Restore;
 import com.netflix.nfsidecar.config.AWSCommonConfig;
 import com.netflix.nfsidecar.config.CassCommonConfig;
 import com.netflix.nfsidecar.config.CommonConfig;
+import com.netflix.nfsidecar.config.RedisConfig;
 import com.netflix.nfsidecar.identity.IInstanceState;
 import com.netflix.nfsidecar.identity.IMembership;
 import com.netflix.nfsidecar.identity.InstanceEnvIdentity;
 import com.netflix.nfsidecar.instance.InstanceDataRetriever;
 import com.netflix.nfsidecar.instance.LocalInstanceDataRetriever;
-import com.netflix.nfsidecar.instance.VpcInstanceDataRetriever;
 import com.netflix.nfsidecar.resources.env.IEnvVariables;
 import com.netflix.nfsidecar.resources.env.InstanceEnvVariables;
 import com.netflix.nfsidecar.supplier.HostSupplier;
@@ -60,6 +53,10 @@ import com.netflix.nfsidecar.tokensdb.CassandraInstanceFactory;
 import com.netflix.nfsidecar.tokensdb.IAppsInstanceFactory;
 import com.netflix.nfsidecar.utils.ProcessTuner;
 import com.netflix.runtime.health.guice.HealthModule;
+import org.quartz.SchedulerFactory;
+import org.quartz.impl.StdSchedulerFactory;
+
+import javax.inject.Singleton;
 
 /**
  * This is the "main" module where we wire everything up. If you see this module
@@ -141,5 +138,11 @@ public final class FloridaModule extends AbstractModule {
     @Singleton
     FloridaConfig getFloridaConfig(ConfigProxyFactory factory) {
         return factory.newProxy(FloridaConfig.class);
+    }
+
+    @Provides
+    @Singleton
+    RedisConfig getRedisConfig(final ConfigProxyFactory factory) {
+        return factory.newProxy(RedisConfig.class);
     }
 }


### PR DESCRIPTION
We have a bit of a different setup here, and so I needed to alter how redis is managed and addressed.  Seemed like a reasonable place to add a configuration object, so I did so, maintaining the old hard-coded values as defaults.