### PR TITLE
Expose zset-max-ziplist-value config via FP

### DIFF
--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/config/FloridaConfig.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/config/FloridaConfig.java
@@ -277,6 +277,10 @@ public interface FloridaConfig {
     @PropertyName(name = "dyno.persistence.type")
     public String persistenceType();
 
+    @DefaultValue("-1")
+    @PropertyName(name = "dyno.redis.zset.maxZipListValue")
+    public int getRedisMaxZsetZiplistValue();
+
     // Storage engine: ARDB with RocksDB
     // =================================
 

--- a/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
+++ b/dynomitemanager-core/src/main/java/com/netflix/dynomitemanager/storage/RedisStorageProxy.java
@@ -63,6 +63,7 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
     private static final String REDIS_CONF_UNIXSOCKETPERM = "^\\s*unixsocketperm\\s*[0-9]*";
     private static final String REDIS_CONF_PUBSUB = "notify-keyspace-events";
     private static final String REDIS_CONF_DAEMONIZE = "^daemonize\\s*[a-zA-Z]*";
+    private static final String REDIS_CONF_ZSET_MAXZIPLISTVALUE = "^zset-max-ziplist-value\\s*[0-9][0-9]*[a-zA-Z]*";
 
     private static final Logger logger = LoggerFactory.getLogger(RedisStorageProxy.class);
     public static final String JOB_TASK_NAME = "REDIS HEALTH TRACKER";
@@ -705,6 +706,10 @@ public class RedisStorageProxy extends Task implements StorageProxy, HealthIndic
                                                                  // RDB
                         logger.info("Updating Redis property: " + saveSchedule);
                         lines.set(i, saveSchedule);
+                    } else if (line.matches(REDIS_CONF_ZSET_MAXZIPLISTVALUE) && config.getRedisMaxZsetZiplistValue() != -1) {
+                        String zsetMaxZiplistValue = REDIS_CONF_ZSET_MAXZIPLISTVALUE + " " + config.getRedisMaxZsetZiplistValue();
+                        logger.info("Updating Redis property: " + zsetMaxZiplistValue);
+                        lines.set(i, zsetMaxZiplistValue);
                     }
                 } else if (config.isPersistenceEnabled() && !config.persistenceType().equals("aof")) {
                     if (line.matches(REDIS_CONF_STOP_WRITES_BGSAVE_ERROR)) {


### PR DESCRIPTION
We've received a use-case request where the user would like to have
the zset-max-ziplist-value configurable as the minimum size of an
item's data is larger than the default values per item in the zset
ziplist representation. This would convert all zsets to non-ziplist
representations which have a higher memory overhead.

This patch allows setting this via FP to make more efficient use
of memory, i.e. reduce memory overhead for zsets in the cluster.