### PR TITLE
Replace jcenter with maven central 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 
 buildscript {
-  repositories { jcenter() }
+    repositories {
+        mavenCentral()
+        maven {
+            url = 'https://plugins.gradle.org/m2'
+        }
+    }
    dependencies {
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:latest.release'
         classpath "org.akhikhl.gretty:gretty:latest.release"


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

